### PR TITLE
Reorganize samples into lib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,25 +10,25 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Build
-        run: cargo build --verbose
+  # build:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Cache
+  #       uses: actions/cache@v3
+  #       with:
+  #         path: |
+  #           ~/.cargo/registry
+  #           ~/.cargo/git
+  #           target
+  #         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+  #     - name: Install Rust
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         override: true
+  #     - name: Build
+  #       run: cargo build --verbose
 
   fmt:
     runs-on: ubuntu-latest
@@ -76,7 +76,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    needs: [build]
+    # needs: [build]
     steps:
       - uses: actions/checkout@v3
       - name: Cache

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ tokio = { version = "1.29", features = ["full"] }
 tower = "0.4.13"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+slug = "0.1.4"

--- a/src/bin/dev.rs
+++ b/src/bin/dev.rs
@@ -7,6 +7,8 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
+use inngest::router::axum as inngest_axum;
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 struct App {
     #[serde(rename = "appName")]
@@ -60,7 +62,7 @@ async fn main() {
     // build our application with a single route
     let app = Router::new()
         .route("/", get(|| async { "Hello, World!" }))
-        .route("/api/inngest", put(register).post(invoke));
+        .route("/api/inngest", put(inngest_axum::register).post(invoke));
 
     // run it with hyper on localhost:3000
     axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())

--- a/src/bin/dev.rs
+++ b/src/bin/dev.rs
@@ -1,126 +1,20 @@
-use std::collections::HashMap;
-
 use axum::{
     routing::{get, put},
     Router,
 };
-use serde::{Deserialize, Serialize};
-use serde_json::json;
 
 use inngest::router::axum as inngest_axum;
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-struct App {
-    #[serde(rename = "appName")]
-    app_name: String,
-    #[serde(rename = "deployType")]
-    deploy_type: String,
-    url: String,
-    v: String,
-    sdk: String,
-    framework: String,
-    functions: Vec<Function>,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-struct Trigger {
-    event: Option<String>,
-    expression: Option<String>,
-    // cron: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-struct Function {
-    id: String,
-    name: String,
-    triggers: Vec<Trigger>,
-    steps: HashMap<String, FunctionStep>,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-struct FunctionStep {
-    id: String,
-    name: String,
-    runtime: FunctionStepRuntime,
-    retries: FunctionStepRetry,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-struct FunctionStepRetry {
-    attempts: u8,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-struct FunctionStepRuntime {
-    url: String,
-    #[serde(rename = "type")]
-    method: String,
-}
 
 #[tokio::main]
 async fn main() {
     // build our application with a single route
     let app = Router::new()
         .route("/", get(|| async { "Hello, World!" }))
-        .route("/api/inngest", put(inngest_axum::register).post(invoke));
+        .route("/api/inngest", put(inngest_axum::register));
 
     // run it with hyper on localhost:3000
     axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
         .serve(app.into_make_service())
         .await
         .unwrap();
-}
-
-async fn register() -> Result<(), String> {
-    let client = reqwest::Client::new();
-    let mut steps = HashMap::new();
-    steps.insert(
-        "step".to_string(),
-        FunctionStep {
-            id: "step".to_string(),
-            name: "step".to_string(),
-            runtime: FunctionStepRuntime {
-                url: "http://127.0.0.1:3000/api/inngest?fnId=dummy-func&step=step".to_string(),
-                method: "http".to_string(),
-            },
-            retries: FunctionStepRetry { attempts: 3 },
-        },
-    );
-
-    let func = Function {
-        id: "dummy-func".to_string(),
-        name: "Dummy func".to_string(),
-        triggers: vec![Trigger {
-            event: Some("test/event".to_string()),
-            expression: None,
-            // cron: None,
-        }],
-        steps,
-    };
-
-    let payload = App {
-        app_name: "InngestApp".to_string(),
-        deploy_type: "ping".to_string(),
-        url: "http://127.0.0.1:3000/api/inngest".to_string(),
-        v: "1".to_string(),
-        sdk: "rust:v0.0.1".to_string(),
-        framework: "axum".to_string(),
-        functions: vec![func],
-    };
-
-    println!("Payload: {:#?}", json!(payload));
-
-    match client
-        .post("http://127.0.0.1:8288/fn/register")
-        .json(&payload)
-        .send()
-        .await
-    {
-        Ok(_) => Ok(()),
-        Err(_) => Err("error".to_string()),
-    }
-}
-
-async fn invoke() -> &'static str {
-    "Invoke"
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,4 @@
+pub enum Error {
+    RetriableError,
+    NonRetriableError,
+}

--- a/src/function.rs
+++ b/src/function.rs
@@ -48,47 +48,42 @@ impl ServableFunction {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Function {
-    id: String,
-    name: String,
-    triggers: Vec<Trigger>,
-    steps: HashMap<String, Step>,
+    pub id: String,
+    pub name: String,
+    pub triggers: Vec<Trigger>,
+    pub steps: HashMap<String, Step>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Step {
-    id: String,
-    name: String,
-    runtime: StepRuntime,
-    retries: StepRetry,
+    pub id: String,
+    pub name: String,
+    pub runtime: StepRuntime,
+    pub retries: StepRetry,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct StepRuntime {
-    url: String,
+    pub url: String,
     #[serde(rename = "type")]
-    method: String,
+    pub method: String,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct StepRetry {
-    attempts: u8,
+    pub attempts: u8,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
 pub enum Trigger {
-    Event(EventTrigger),
-    Cron(CronTrigger),
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct EventTrigger {
-    event: String,
-    expression: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct CronTrigger {
-    cron: String,
+    EventTrigger {
+        event: String,
+        expression: Option<String>,
+    },
+    CronTrigger {
+        cron: String,
+    },
 }
 
 pub fn create_function<T>(opts: FunctionOps, trigger: Trigger) -> ServableFunction {

--- a/src/function.rs
+++ b/src/function.rs
@@ -27,13 +27,13 @@ pub struct FunctionOps {
 }
 
 #[derive(Debug, Clone)]
-pub struct ServableFunction<T> {
+pub struct ServableFunction {
     opts: FunctionOps,
     trigger: Trigger,
-    func: SdkFunction<T>,
+    // func: SdkFunction,
 }
 
-impl<T> ServableFunction<T> {
+impl ServableFunction {
     pub fn slug(&self) -> String {
         match &self.opts.id {
             Some(id) => id.clone(),
@@ -91,14 +91,6 @@ pub struct CronTrigger {
     cron: String,
 }
 
-pub fn create_function<T>(
-    opts: FunctionOps,
-    trigger: Trigger,
-    func: dyn Any,
-) -> ServableFunction<T> {
-    ServableFunction {
-        opts,
-        trigger,
-        func,
-    }
+pub fn create_function<T>(opts: FunctionOps, trigger: Trigger) -> ServableFunction {
+    ServableFunction { opts, trigger }
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,63 +1,55 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 // #[derive(Debug, Clone, Deserialize, Serialize)]
 pub trait ServableFunction {
     fn slug(&self) -> String;
     fn name(&self) -> String;
-    fn trigger(&self) -> Box<dyn Trigger>;
+    fn trigger(&self) -> Trigger;
 }
 
-#[derive(Debug, Clone)]
-pub struct FunctionOps {
-    id: String,
-    name: String,
-    retries: u8,
-}
-
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Function {
-    opts: FunctionOps,
-    trigger: Box<dyn Trigger>,
-    // TODO: the actual function
-}
-
-pub struct SdkFunction {
     id: String,
     name: String,
-    triggers: Vec<Box<dyn Trigger>>,
+    triggers: Vec<Trigger>,
+    steps: HashMap<String, Step>,
 }
 
-pub trait Trigger {
-    fn trigger(&self) -> String;
-    fn expression(&self) -> Option<String>;
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Step {
+    id: String,
+    name: String,
+    runtime: StepRuntime,
+    retries: StepRetry,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
+pub struct StepRuntime {
+    url: String,
+    #[serde(rename = "type")]
+    method: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct StepRetry {
+    attempts: u8,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum Trigger {
+    Event(EventTrigger),
+    Cron(CronTrigger),
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct EventTrigger {
     event: String,
     expression: Option<String>,
 }
 
-impl Trigger for EventTrigger {
-    fn trigger(&self) -> String {
-        self.event.clone()
-    }
-
-    fn expression(&self) -> Option<String> {
-        self.expression.clone()
-    }
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct CronTrigger {
     cron: String,
-}
-
-impl Trigger for CronTrigger {
-    fn trigger(&self) -> String {
-        self.cron.clone()
-    }
-
-    fn expression(&self) -> Option<String> {
-        None
-    }
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,0 +1,18 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ServableFunction {
+    slug: String,
+    name: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct EventTrigger {
+    event: String,
+    expression: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CronTrigger {
+    cron: String,
+}

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,9 +1,28 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ServableFunction {
-    slug: String,
+// #[derive(Debug, Clone, Deserialize, Serialize)]
+pub trait ServableFunction {
+    fn slug() -> String;
+    fn name() -> String;
+    fn trigger() -> Box<dyn Trigger>;
+}
+
+#[derive(Debug, Clone)]
+pub struct FunctionOps {
+    id: String,
     name: String,
+    retries: u8,
+}
+
+pub struct Function {
+    opts: FunctionOps,
+    trigger: Box<dyn Trigger>,
+    // TODO: the actual function
+}
+
+pub trait Trigger {
+    fn trigger(&self) -> String;
+    fn expression(&self) -> Option<String>;
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -12,7 +31,27 @@ pub struct EventTrigger {
     expression: Option<String>,
 }
 
+impl Trigger for EventTrigger {
+    fn trigger(&self) -> String {
+        self.event.clone()
+    }
+
+    fn expression(&self) -> Option<String> {
+        self.expression.clone()
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CronTrigger {
     cron: String,
+}
+
+impl Trigger for CronTrigger {
+    fn trigger(&self) -> String {
+        self.cron.clone()
+    }
+
+    fn expression(&self) -> Option<String> {
+        None
+    }
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -2,9 +2,9 @@ use serde::{Deserialize, Serialize};
 
 // #[derive(Debug, Clone, Deserialize, Serialize)]
 pub trait ServableFunction {
-    fn slug() -> String;
-    fn name() -> String;
-    fn trigger() -> Box<dyn Trigger>;
+    fn slug(&self) -> String;
+    fn name(&self) -> String;
+    fn trigger(&self) -> Box<dyn Trigger>;
 }
 
 #[derive(Debug, Clone)]
@@ -18,6 +18,12 @@ pub struct Function {
     opts: FunctionOps,
     trigger: Box<dyn Trigger>,
     // TODO: the actual function
+}
+
+pub struct SdkFunction {
+    id: String,
+    name: String,
+    triggers: Vec<Box<dyn Trigger>>,
 }
 
 pub trait Trigger {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod error;
 pub mod function;
 pub mod router;
 pub mod sdk;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+pub mod function;
+pub mod router;
+
 pub fn add(left: usize, right: usize) -> usize {
     left + right
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod function;
 pub mod router;
+pub mod sdk;
 
 pub fn add(left: usize, right: usize) -> usize {
     left + right

--- a/src/router/axum.rs
+++ b/src/router/axum.rs
@@ -3,7 +3,6 @@ use crate::{
     sdk::Request,
 };
 
-use serde_json::json;
 use std::{collections::HashMap, default::Default};
 
 pub async fn register() -> Result<(), String> {
@@ -37,8 +36,6 @@ pub async fn register() -> Result<(), String> {
         url: "http://127.0.0.1:3000/api/inngest".to_string(),
         ..Default::default()
     };
-
-    println!("Payload: {:#?}", json!(&req));
 
     let client = reqwest::Client::new();
 

--- a/src/router/axum.rs
+++ b/src/router/axum.rs
@@ -1,5 +1,54 @@
-pub async fn register() -> Result<(), String> {
-    println!("Register");
+use crate::{
+    function::{Function, Step, StepRetry, StepRuntime, Trigger},
+    sdk::Request,
+};
 
-    Ok(())
+use serde_json::json;
+use std::{collections::HashMap, default::Default};
+
+pub async fn register() -> Result<(), String> {
+    let mut steps = HashMap::new();
+    steps.insert(
+        "step".to_string(),
+        Step {
+            id: "step".to_string(),
+            name: "step".to_string(),
+            runtime: StepRuntime {
+                url: "http://127.0.0.1:3000/api/inngest?fnId=dummy-func&step=step".to_string(),
+                method: "http".to_string(),
+            },
+            retries: StepRetry { attempts: 3 },
+        },
+    );
+
+    let func = Function {
+        id: "dummy-func".to_string(),
+        name: "Dummy func".to_string(),
+        triggers: vec![Trigger::EventTrigger {
+            event: "test/event".to_string(),
+            expression: None,
+        }],
+        steps,
+    };
+
+    let req = Request {
+        framework: "axum".to_string(),
+        functions: vec![func],
+        url: "http://127.0.0.1:3000/api/inngest".to_string(),
+        ..Default::default()
+    };
+
+    println!("Payload: {:#?}", json!(&req));
+
+    let client = reqwest::Client::new();
+
+    match client
+        .post("http://127.0.0.1:8288/fn/register")
+        .json(&req)
+        .send()
+        .await
+    {
+        Ok(_) => Ok(()),
+        Err(_) => Err("error".to_string()),
+    }
 }

--- a/src/router/axum.rs
+++ b/src/router/axum.rs
@@ -1,0 +1,5 @@
+pub async fn register() -> Result<(), String> {
+    println!("Register");
+
+    Ok(())
+}

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -3,12 +3,12 @@ pub mod axum;
 use crate::function::ServableFunction;
 use std::default::Default;
 
-pub struct Handler<T> {
+pub struct Handler {
     app_name: String,
-    funcs: Vec<ServableFunction<T>>,
+    funcs: Vec<ServableFunction>,
 }
 
-impl<T> Handler<T> {
+impl Handler {
     pub fn new() -> Self {
         Self::default()
     }
@@ -17,16 +17,16 @@ impl<T> Handler<T> {
         self.app_name = name.to_string()
     }
 
-    pub fn register_fn(&mut self, func: &ServableFunction<T>) {
+    pub fn register_fn(&mut self, func: &ServableFunction) {
         self.funcs.push(func.clone());
     }
 
-    pub fn register_fns(&mut self, funcs: &[ServableFunction<T>]) {
+    pub fn register_fns(&mut self, funcs: &[ServableFunction]) {
         self.funcs.extend_from_slice(funcs)
     }
 }
 
-impl<T> Default for Handler<T> {
+impl Default for Handler {
     fn default() -> Self {
         Handler {
             app_name: String::new(),

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -1,0 +1,15 @@
+pub mod axum;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SdkRequest {
+    #[serde(rename = "appName")]
+    app_name: String,
+    #[serde(rename = "deployType")]
+    deploy_type: String,
+    url: String,
+    v: String,
+    sdk: String,
+    framework: String,
+}

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -1,8 +1,36 @@
 pub mod axum;
 
 use crate::function::ServableFunction;
+use std::default::Default;
 
-pub struct Handler {
+pub struct Handler<T> {
     app_name: String,
-    funcs: Vec<Box<dyn ServableFunction>>,
+    funcs: Vec<ServableFunction<T>>,
+}
+
+impl<T> Handler<T> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn set_name(&mut self, name: &str) {
+        self.app_name = name.to_string()
+    }
+
+    pub fn register_fn(&mut self, func: &ServableFunction<T>) {
+        self.funcs.push(func.clone());
+    }
+
+    pub fn register_fns(&mut self, funcs: &[ServableFunction<T>]) {
+        self.funcs.extend_from_slice(funcs)
+    }
+}
+
+impl<T> Default for Handler<T> {
+    fn default() -> Self {
+        Handler {
+            app_name: String::new(),
+            funcs: vec![],
+        }
+    }
 }

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -1,15 +1,8 @@
 pub mod axum;
 
-use serde::{Deserialize, Serialize};
+use crate::function::ServableFunction;
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct SdkRequest {
-    #[serde(rename = "appName")]
+pub struct Handler {
     app_name: String,
-    #[serde(rename = "deployType")]
-    deploy_type: String,
-    url: String,
-    v: String,
-    sdk: String,
-    framework: String,
+    funcs: Vec<Box<dyn ServableFunction>>,
 }

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -1,6 +1,8 @@
+use crate::function::Function;
+
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Request {
     #[serde(rename = "appName")]
     app_name: String,
@@ -10,4 +12,5 @@ pub struct Request {
     v: String,
     sdk: String,
     framework: String,
+    functions: Vec<Function>,
 }

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -1,0 +1,13 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Request {
+    #[serde(rename = "appName")]
+    app_name: String,
+    #[serde(rename = "deployType")]
+    deploy_type: String,
+    url: String,
+    v: String,
+    sdk: String,
+    framework: String,
+}

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -1,16 +1,31 @@
 use crate::function::Function;
 
 use serde::{Deserialize, Serialize};
+use std::default::Default;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Request {
     #[serde(rename = "appName")]
-    app_name: String,
+    pub app_name: String,
     #[serde(rename = "deployType")]
-    deploy_type: String,
-    url: String,
-    v: String,
-    sdk: String,
-    framework: String,
-    functions: Vec<Function>,
+    pub deploy_type: String,
+    pub url: String,
+    pub v: String,
+    pub sdk: String,
+    pub framework: String,
+    pub functions: Vec<Function>,
+}
+
+impl Default for Request {
+    fn default() -> Self {
+        Request {
+            app_name: "InngestApp".to_string(),
+            deploy_type: "ping".to_string(),
+            url: "".to_string(),
+            v: "1".to_string(),
+            sdk: "rust:v0.0.1".to_string(),
+            framework: "rust".to_string(),
+            functions: vec![],
+        }
+    }
 }

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -18,12 +18,14 @@ pub struct Request {
 
 impl Default for Request {
     fn default() -> Self {
+        let version = env!("CARGO_PKG_VERSION");
+
         Request {
             app_name: "InngestApp".to_string(),
             deploy_type: "ping".to_string(),
             url: "".to_string(),
             v: "1".to_string(),
-            sdk: "rust:v0.0.1".to_string(),
+            sdk: format!("rust:v{}", version),
             framework: "rust".to_string(),
             functions: vec![],
         }


### PR DESCRIPTION
Move PoC code for registration of an Inngest app and functions into lib.
Using `inngestgo` as reference.