### PR TITLE
Implement `InngestEvent` macro

### DIFF
--- a/inngest/examples/axum/main.rs
+++ b/inngest/examples/axum/main.rs
@@ -7,6 +7,7 @@ use inngest::{
     function::{create_function, FunctionOps, Input, ServableFunction, Trigger},
     router::{axum as inngest_axum, Handler},
 };
+use inngest_macros::InngestEvent;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -33,36 +34,10 @@ async fn main() {
         .unwrap();
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, InngestEvent)]
 struct DummyEvent {
+    name: String,
     data: u8,
-}
-
-#[typetag::serde]
-impl Event for DummyEvent {
-    fn id(&self) -> Option<String> {
-        None
-    }
-
-    fn name(&self) -> String {
-        "test/event".to_string()
-    }
-
-    fn data(&self) -> &dyn std::any::Any {
-        &self.data
-    }
-
-    fn user(&self) -> Option<&dyn std::any::Any> {
-        None
-    }
-
-    fn timestamp(&self) -> Option<u64> {
-        None
-    }
-
-    fn version(&self) -> Option<String> {
-        None
-    }
 }
 
 fn dummy_fn() -> Box<dyn ServableFunction + Sync + Send> {

--- a/inngest/examples/event_serde/main.rs
+++ b/inngest/examples/event_serde/main.rs
@@ -15,17 +15,6 @@ struct DummyData {
     bar: u8,
 }
 
-// #[typetag::serde]
-// impl Event for DummyEvent {
-//     fn name(&self) -> String {
-//         "test/event".to_string()
-//     }
-
-//     fn data(&self) -> &dyn std::any::Any {
-//         &self.data
-//     }
-// }
-
 fn main() {
     let event = DummyEvent {
         name: "test/event".to_string(),
@@ -51,6 +40,10 @@ fn main() {
             "user": {},
         }
     });
+
+    println!("ID: {:?}", event.id());
+    println!("Name: {:?}", event.name());
+    println!("Data: {:?}", event.data());
 
     match serde_json::from_value::<Box<dyn Event>>(jval) {
         Ok(result) => println!("Result: {:?}", result),

--- a/inngest/examples/event_serde/main.rs
+++ b/inngest/examples/event_serde/main.rs
@@ -5,6 +5,7 @@ use serde_json::json;
 
 #[derive(Serialize, Deserialize, Debug, InngestEvent)]
 struct DummyEvent {
+    id: String,
     name: String,
     data: DummyData,
 }
@@ -17,6 +18,7 @@ struct DummyData {
 
 fn main() {
     let event = DummyEvent {
+        id: "something".to_string(),
         name: "test/event".to_string(),
         data: DummyData {
             foo: "hello".to_string(),

--- a/inngest/examples/send_events/main.rs
+++ b/inngest/examples/send_events/main.rs
@@ -1,6 +1,5 @@
-use std::any::Any;
-
 use inngest::event::{send_event, send_events, Event};
+use inngest_macros::InngestEvent;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -9,37 +8,10 @@ struct Data {
     bar: u8,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, InngestEvent)]
 struct TestEvent {
     name: String,
     data: Data,
-}
-
-#[typetag::serde]
-impl Event for TestEvent {
-    fn id(&self) -> Option<String> {
-        None
-    }
-
-    fn name(&self) -> String {
-        "test/event".to_string()
-    }
-
-    fn data(&self) -> &dyn Any {
-        &self.data
-    }
-
-    fn user(&self) -> Option<&dyn Any> {
-        None
-    }
-
-    fn timestamp(&self) -> Option<u64> {
-        None
-    }
-
-    fn version(&self) -> Option<String> {
-        None
-    }
 }
 
 #[tokio::main]

--- a/inngest/src/event.rs
+++ b/inngest/src/event.rs
@@ -1,3 +1,4 @@
+use serde_json::{json, Value};
 use std::{any::Any, fmt::Debug};
 
 #[typetag::serde(tag = "type", content = "value")]
@@ -25,10 +26,13 @@ pub trait Event: Debug {
 pub async fn send_event(event: &dyn Event) -> Result<(), String> {
     let client = reqwest::Client::new();
 
+    // Take the value where the content is
+    let payload = &json!(event)["value"];
+
     // TODO: make the result return something properly
     match client
         .post("http://127.0.0.1:8288/e/test")
-        .json(event)
+        .json(payload)
         .send()
         .await
     {
@@ -40,10 +44,15 @@ pub async fn send_event(event: &dyn Event) -> Result<(), String> {
 pub async fn send_events(events: &[&dyn Event]) -> Result<(), String> {
     let client = reqwest::Client::new();
 
+    let payload: Vec<Value> = events
+        .iter()
+        .map(|evt| json!(evt)["value"].clone())
+        .collect();
+
     // TODO: make the result return something properly
     match client
         .post("http://127.0.0.1:8288/e/test")
-        .json(events)
+        .json(&payload)
         .send()
         .await
     {

--- a/inngest/src/event.rs
+++ b/inngest/src/event.rs
@@ -13,7 +13,7 @@ pub trait Event: Debug {
         None
     }
 
-    fn timestamp(&self) -> Option<u64> {
+    fn timestamp(&self) -> Option<i64> {
         None
     }
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -6,59 +6,31 @@ use syn::{parse_macro_input, DeriveInput};
 pub fn derive_event_trait(item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as DeriveInput);
 
-    let ident = input.ident;
-    let mut event = EventFields::default();
+    let ident = input.ident.clone();
+    let has_id_field = has_field(&input, "id");
+    let has_name_field = has_field(&input, "name");
+    let has_data_field = has_field(&input, "data");
+    let has_user_field = has_field(&input, "user");
+    let has_ts_field = has_field(&input, "ts");
+    let has_v_field = has_field(&input, "v");
 
-    println!("Ident: {:?}", ident);
-
-    // TODO:
-    // - [x] retrieve fields from struct
-    // - [x] check that `name`, `data` field exists
-    // - [x] emit compile error if `name` or `data` is not a field
-    // - [ ] check if any of these fields exists (id, user, ts, v)
-    match input.data {
-        syn::Data::Struct(data) => {
-            // println!("Fields: {:#?}", data.fields);
-            match data.fields {
-                syn::Fields::Named(nf) => {
-                    for n in nf.named.iter() {
-                        if let Some(ident) = &n.ident {
-                            match ident.to_string().as_str() {
-                                "name" => {
-                                    event.name = true;
-                                }
-                                "data" => {
-                                    event.data = true;
-                                }
-                                field => {
-                                    println!("Unsupported field: {:?}", field);
-                                }
-                            }
-                        }
-                    }
-                }
-                _ => (),
-            };
-        }
-        _ => panic!("Invalid types"),
+    if !has_name_field || !has_data_field {
+        panic!("name and data fields are required");
     }
 
-    if !event.is_valid() {
-        println!("Event: {:#?}", event);
-        panic!("The event need to have a `name` and `data` field");
-    }
-
-    // - [ ] rotate through the list of fields and implement the trait function
-    // for each of them appropriately
     let expanded = quote! {
         #[typetag::serde]
         impl Event for #ident {
             fn id(&self) -> Option<String> {
-                None
+                if #has_id_field {
+                    Some(self.id.clone())
+                } else {
+                    None
+                }
             }
 
             fn name(&self) -> String {
-                "test/event".to_string()
+                self.name.clone()
             }
 
             fn data(&self) -> &dyn std::any::Any {
@@ -66,15 +38,27 @@ pub fn derive_event_trait(item: TokenStream) -> TokenStream {
             }
 
             fn user(&self) -> Option<&dyn std::any::Any> {
-                None
+                if #has_user_field {
+                    Some(&self.user)
+                } else {
+                    None
+                }
             }
 
             fn timestamp(&self) -> Option<i64> {
-                None
+                if #has_ts_field {
+                    Some(self.ts)
+                } else {
+                    None
+                }
             }
 
             fn version(&self) -> Option<String> {
-                None
+                if #has_v_field {
+                    Some(self.v.clone())
+                } else {
+                    None
+                }
             }
 
         }
@@ -84,18 +68,16 @@ pub fn derive_event_trait(item: TokenStream) -> TokenStream {
     TokenStream::from(expanded)
 }
 
-#[derive(Debug, Default)]
-struct EventFields {
-    id: bool,
-    name: bool,
-    data: bool,
-    user: bool,
-    ts: bool,
-    timestamp: bool,
-}
-
-impl EventFields {
-    fn is_valid(&self) -> bool {
-        self.name && self.data
+fn has_field(input: &DeriveInput, field_name: &str) -> bool {
+    if let syn::Data::Struct(data) = &input.data {
+        data.fields.iter().any(|field| {
+            if let Some(ident) = &field.ident {
+                ident.to_string() == field_name
+            } else {
+                false
+            }
+        })
+    } else {
+        false
     }
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -7,26 +7,28 @@ pub fn derive_event_trait(item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as DeriveInput);
 
     let ident = input.ident.clone();
-    let has_id_field = has_field(&input, "id");
+    // let has_id_field = has_field(&input, "id");
     let has_name_field = has_field(&input, "name");
     let has_data_field = has_field(&input, "data");
-    let has_user_field = has_field(&input, "user");
-    let has_ts_field = has_field(&input, "ts");
-    let has_v_field = has_field(&input, "v");
+    // let has_user_field = has_field(&input, "user");
+    // let has_ts_field = has_field(&input, "ts");
+    // let has_v_field = has_field(&input, "v");
 
     if !has_name_field || !has_data_field {
         panic!("name and data fields are required");
     }
 
+    // let id_value: Option<String> = None;
+    // let user_value: Option<&dyn std::any::Any> = None;
+    // let ts_value: Option<i64> = None;
+    // let v_value: Option<String> = None;
+
     let expanded = quote! {
         #[typetag::serde]
         impl Event for #ident {
             fn id(&self) -> Option<String> {
-                if #has_id_field {
-                    Some(self.id.clone())
-                } else {
-                    None
-                }
+                // #id_value
+                None
             }
 
             fn name(&self) -> String {
@@ -38,27 +40,15 @@ pub fn derive_event_trait(item: TokenStream) -> TokenStream {
             }
 
             fn user(&self) -> Option<&dyn std::any::Any> {
-                if #has_user_field {
-                    Some(&self.user)
-                } else {
-                    None
-                }
+                None
             }
 
             fn timestamp(&self) -> Option<i64> {
-                if #has_ts_field {
-                    Some(self.ts)
-                } else {
-                    None
-                }
+                None
             }
 
             fn version(&self) -> Option<String> {
-                if #has_v_field {
-                    Some(self.v.clone())
-                } else {
-                    None
-                }
+                None
             }
 
         }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -10,9 +10,9 @@ pub fn derive_event_trait(item: TokenStream) -> TokenStream {
     let has_id_field = has_field(&input, "id");
     let has_name_field = has_field(&input, "name");
     let has_data_field = has_field(&input, "data");
-    // let has_user_field = has_field(&input, "user");
-    // let has_ts_field = has_field(&input, "ts");
-    // let has_v_field = has_field(&input, "v");
+    let has_user_field = has_field(&input, "user");
+    let has_ts_field = has_field(&input, "ts");
+    let has_v_field = has_field(&input, "v");
 
     if !has_name_field || !has_data_field {
         panic!("name and data fields are required");
@@ -23,16 +23,27 @@ pub fn derive_event_trait(item: TokenStream) -> TokenStream {
     } else {
         quote! { None }
     };
-    // let user_value: Option<&dyn std::any::Any> = None;
-    // let ts_value: Option<i64> = None;
-    // let v_value: Option<String> = None;
+    let user_value = if has_user_field {
+        quote! { Some(&self.user) }
+    } else {
+        quote! { None }
+    };
+    let ts_value = if has_ts_field {
+        quote! { Some(self.ts) }
+    } else {
+        quote! { None }
+    };
+    let v_value = if has_v_field {
+        quote! { Some(self.v.clone()) }
+    } else {
+        quote! { None }
+    };
 
     let expanded = quote! {
         #[typetag::serde]
         impl Event for #ident {
             fn id(&self) -> Option<String> {
                 #id_value
-                // None
             }
 
             fn name(&self) -> String {
@@ -44,21 +55,20 @@ pub fn derive_event_trait(item: TokenStream) -> TokenStream {
             }
 
             fn user(&self) -> Option<&dyn std::any::Any> {
-                None
+                #user_value
             }
 
             fn timestamp(&self) -> Option<i64> {
-                None
+                #ts_value
             }
 
             fn version(&self) -> Option<String> {
-                None
+                #v_value
             }
 
         }
     };
 
-    // TokenStream::new()
     TokenStream::from(expanded)
 }
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -7,7 +7,7 @@ pub fn derive_event_trait(item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as DeriveInput);
 
     let ident = input.ident.clone();
-    // let has_id_field = has_field(&input, "id");
+    let has_id_field = has_field(&input, "id");
     let has_name_field = has_field(&input, "name");
     let has_data_field = has_field(&input, "data");
     // let has_user_field = has_field(&input, "user");
@@ -18,7 +18,11 @@ pub fn derive_event_trait(item: TokenStream) -> TokenStream {
         panic!("name and data fields are required");
     }
 
-    // let id_value: Option<String> = None;
+    let id_value = if has_id_field {
+        quote! { Some(self.id.clone()) }
+    } else {
+        quote! { None }
+    };
     // let user_value: Option<&dyn std::any::Any> = None;
     // let ts_value: Option<i64> = None;
     // let v_value: Option<String> = None;
@@ -27,8 +31,8 @@ pub fn derive_event_trait(item: TokenStream) -> TokenStream {
         #[typetag::serde]
         impl Event for #ident {
             fn id(&self) -> Option<String> {
-                // #id_value
-                None
+                #id_value
+                // None
             }
 
             fn name(&self) -> String {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -7,24 +7,56 @@ pub fn derive_event_trait(item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as DeriveInput);
 
     let ident = input.ident;
+    let mut event = EventFields::default();
+
     println!("Ident: {:?}", ident);
+
+    // TODO:
+    // - [x] retrieve fields from struct
+    // - [x] check that `name`, `data` field exists
+    // - [x] emit compile error if `name` or `data` is not a field
+    // - [ ] check if any of these fields exists (id, user, ts, v)
     match input.data {
         syn::Data::Struct(data) => {
-            println!("Fields: {:#?}", data.fields);
+            // println!("Fields: {:#?}", data.fields);
+            match data.fields {
+                syn::Fields::Named(nf) => {
+                    for n in nf.named.iter() {
+                        if let Some(ident) = &n.ident {
+                            match ident.to_string().as_str() {
+                                "name" => {
+                                    event.name = true;
+                                }
+                                "data" => {
+                                    event.data = true;
+                                }
+                                field => {
+                                    println!("Unsupported field: {:?}", field);
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => (),
+            };
         }
         _ => panic!("Invalid types"),
     }
 
-    // TODO:
-    // - [ ] retrieve fields from struct
-    // - [ ] check that `name`, `data` field exists
-    // - [ ] emit compile error if `name` or `data` is not a field
-    // - [ ] check if any of these fields exists (id, user, ts, v)
+    if !event.is_valid() {
+        println!("Event: {:#?}", event);
+        panic!("The event need to have a `name` and `data` field");
+    }
+
     // - [ ] rotate through the list of fields and implement the trait function
     // for each of them appropriately
     let expanded = quote! {
         #[typetag::serde]
         impl Event for #ident {
+            fn id(&self) -> Option<String> {
+                None
+            }
+
             fn name(&self) -> String {
                 "test/event".to_string()
             }
@@ -32,9 +64,38 @@ pub fn derive_event_trait(item: TokenStream) -> TokenStream {
             fn data(&self) -> &dyn std::any::Any {
                 &self.data
             }
+
+            fn user(&self) -> Option<&dyn std::any::Any> {
+                None
+            }
+
+            fn timestamp(&self) -> Option<i64> {
+                None
+            }
+
+            fn version(&self) -> Option<String> {
+                None
+            }
+
         }
     };
 
     // TokenStream::new()
     TokenStream::from(expanded)
+}
+
+#[derive(Debug, Default)]
+struct EventFields {
+    id: bool,
+    name: bool,
+    data: bool,
+    user: bool,
+    ts: bool,
+    timestamp: bool,
+}
+
+impl EventFields {
+    fn is_valid(&self) -> bool {
+        self.name && self.data
+    }
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -15,6 +15,13 @@ pub fn derive_event_trait(item: TokenStream) -> TokenStream {
         _ => panic!("Invalid types"),
     }
 
+    // TODO:
+    // - [ ] retrieve fields from struct
+    // - [ ] check that `name`, `data` field exists
+    // - [ ] emit compile error if `name` or `data` is not a field
+    // - [ ] check if any of these fields exists (id, user, ts, v)
+    // - [ ] rotate through the list of fields and implement the trait function
+    // for each of them appropriately
     let expanded = quote! {
         #[typetag::serde]
         impl Event for #ident {


### PR DESCRIPTION
Deriving an `InngestEvent` macro will

1. Verify the fields for the struct for essential fields
2. Create the trait implementation based on what fields are available.