### PR TITLE
Add result types

### DIFF
--- a/inngest/examples/axum/main.rs
+++ b/inngest/examples/axum/main.rs
@@ -7,6 +7,7 @@ use inngest::{
     router::{axum as inngest_axum, Handler},
 };
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use std::sync::Arc;
 
 #[tokio::main]
@@ -53,9 +54,8 @@ fn dummy_fn() -> ServableFn<TestData> {
 
             let evt = input.event;
             println!("Event: {}", evt.name);
-            // println!("Data: {:?}", evt.data);
 
-            Ok(Box::new("test result".to_string()))
+            Ok(json!("test result"))
         },
     )
 }
@@ -75,9 +75,8 @@ fn hello_fn() -> ServableFn<TestData> {
 
             let evt = input.event;
             println!("Event: {}", evt.name);
-            // println!("Data: {:?}", evt.data());
 
-            Ok(Box::new("test hello".to_string()))
+            Ok(json!("test hello"))
         },
     )
 }

--- a/inngest/src/error.rs
+++ b/inngest/src/error.rs
@@ -1,4 +1,0 @@
-pub enum Error {
-    RetriableError,
-    NonRetriableError,
-}

--- a/inngest/src/function.rs
+++ b/inngest/src/function.rs
@@ -1,4 +1,7 @@
-use crate::event::{Event, InngestEvent};
+use crate::{
+    event::{Event, InngestEvent},
+    result::Error,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use slug::slugify;
@@ -41,7 +44,7 @@ impl Default for FunctionOps {
 pub struct ServableFn<T: InngestEvent> {
     pub opts: FunctionOps,
     pub trigger: Trigger,
-    pub func: fn(Input<T>) -> Result<Box<dyn Any>, String>,
+    pub func: fn(Input<T>) -> Result<Box<dyn Any>, Error>,
 }
 
 impl<T: InngestEvent> Debug for ServableFn<T> {
@@ -114,7 +117,7 @@ pub enum Trigger {
 pub fn create_function<T: InngestEvent>(
     opts: FunctionOps,
     trigger: Trigger,
-    func: fn(Input<T>) -> Result<Box<dyn Any>, String>,
+    func: fn(Input<T>) -> Result<Box<dyn Any>, Error>,
 ) -> ServableFn<T> {
     ServableFn {
         opts,

--- a/inngest/src/function.rs
+++ b/inngest/src/function.rs
@@ -5,7 +5,7 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use slug::slugify;
-use std::{any::Any, collections::HashMap, fmt::Debug};
+use std::{collections::HashMap, fmt::Debug};
 
 #[derive(Deserialize)]
 pub struct Input<T>
@@ -44,7 +44,7 @@ impl Default for FunctionOps {
 pub struct ServableFn<T: InngestEvent> {
     pub opts: FunctionOps,
     pub trigger: Trigger,
-    pub func: fn(Input<T>) -> Result<Box<dyn Any>, Error>,
+    pub func: fn(Input<T>) -> Result<Value, Error>,
 }
 
 impl<T: InngestEvent> Debug for ServableFn<T> {
@@ -117,7 +117,7 @@ pub enum Trigger {
 pub fn create_function<T: InngestEvent>(
     opts: FunctionOps,
     trigger: Trigger,
-    func: fn(Input<T>) -> Result<Box<dyn Any>, Error>,
+    func: fn(Input<T>) -> Result<Value, Error>,
 ) -> ServableFn<T> {
     ServableFn {
         opts,

--- a/inngest/src/lib.rs
+++ b/inngest/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod error;
 pub mod event;
 pub mod function;
+pub mod result;
 pub mod router;
 pub mod sdk;
 

--- a/inngest/src/lib.rs
+++ b/inngest/src/lib.rs
@@ -1,4 +1,3 @@
-pub mod error;
 pub mod event;
 pub mod function;
 pub mod result;

--- a/inngest/src/result.rs
+++ b/inngest/src/result.rs
@@ -1,4 +1,18 @@
-use std::fmt::{write, Debug, Display};
+use std::{
+    error::Error,
+    fmt::{Debug, Display},
+};
+
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub enum Result<T, E>
+where
+    E: Error,
+{
+    Ok(T),
+    Err(E),
+}
 
 pub struct RetryAfterError {
     pub message: String,

--- a/inngest/src/result.rs
+++ b/inngest/src/result.rs
@@ -1,17 +1,16 @@
-use std::{
-    error::Error,
-    fmt::{Debug, Display},
-};
+use std::fmt::{Debug, Display};
 
-use serde::Serialize;
+#[derive(Debug)]
+pub enum Error {
+    Basic(String),
+    RetryAt(RetryAfterError),
+    NoRetry(NonRetriableError),
+}
 
-#[derive(Serialize)]
-pub enum Result<T, E>
-where
-    E: Error,
-{
-    Ok(T),
-    Err(E),
+pub struct StepError {
+    pub name: String,
+    pub message: String,
+    pub stack: Option<String>,
 }
 
 pub struct RetryAfterError {

--- a/inngest/src/result.rs
+++ b/inngest/src/result.rs
@@ -1,0 +1,54 @@
+use std::fmt::{write, Debug, Display};
+
+pub struct RetryAfterError {
+    pub message: String,
+    pub retry_after: i64,
+    pub cause: Option<String>,
+}
+
+impl Display for RetryAfterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Error: {}, retrying after timestamp: {}",
+            &self.message, &self.retry_after
+        )
+    }
+}
+
+impl Debug for RetryAfterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let cause = match &self.cause {
+            None => String::new(),
+            Some(c) => c.clone(),
+        };
+
+        write!(
+            f,
+            "Error: {}\nRetrying after timestamp: {}\nCause: {}",
+            &self.message, &self.retry_after, &cause
+        )
+    }
+}
+
+pub struct NonRetriableError {
+    pub message: String,
+    pub cause: Option<String>,
+}
+
+impl Display for NonRetriableError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Error: {}, not retrying", &self.message)
+    }
+}
+
+impl Debug for NonRetriableError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let cause = match &self.cause {
+            None => String::new(),
+            Some(c) => c.clone(),
+        };
+
+        write!(f, "Error: {}\nNo retry\nCause: {}", &self.message, &cause)
+    }
+}

--- a/inngest/src/router/axum.rs
+++ b/inngest/src/router/axum.rs
@@ -4,9 +4,7 @@ use axum::{
 };
 use serde_json::Value;
 
-use crate::{
-    event::InngestEvent, router::Handler
-};
+use crate::{event::InngestEvent, router::Handler};
 
 use super::RunQueryParams;
 use std::sync::Arc;
@@ -21,8 +19,10 @@ pub async fn invoke<T: InngestEvent>(
     Query(query): Query<RunQueryParams>,
     State(handler): State<Arc<Handler<T>>>,
     Json(body): Json<Value>,
-) -> Result<(), String> { // TODO: update result types?
-    handler.run(query, &body)
+) -> Result<(), String> {
+    // TODO: update result types?
+    handler
+        .run(query, &body)
         .map(|_| ())
         .map_err(|err| format!("{:?}", err))
 }

--- a/inngest/src/router/axum.rs
+++ b/inngest/src/router/axum.rs
@@ -5,8 +5,7 @@ use axum::{
 use serde_json::Value;
 
 use crate::{
-    event::InngestEvent,
-    router::Handler,
+    event::InngestEvent, router::Handler
 };
 
 use super::RunQueryParams;
@@ -22,6 +21,8 @@ pub async fn invoke<T: InngestEvent>(
     Query(query): Query<RunQueryParams>,
     State(handler): State<Arc<Handler<T>>>,
     Json(body): Json<Value>,
-) -> Result<(), String> {
+) -> Result<(), String> { // TODO: update result types?
     handler.run(query, &body)
+        .map(|_| ())
+        .map_err(|err| format!("{:?}", err))
 }

--- a/inngest/src/router/mod.rs
+++ b/inngest/src/router/mod.rs
@@ -3,9 +3,7 @@ pub mod axum;
 use std::collections::HashMap;
 
 use crate::{
-    event::InngestEvent,
-    function::{Function, Input, InputCtx, ServableFn, Step, StepRetry, StepRuntime},
-    sdk::Request,
+    event::InngestEvent, function::{Function, Input, InputCtx, ServableFn, Step, StepRetry, StepRuntime}, result::Error, sdk::Request
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -85,16 +83,16 @@ where
     }
 
     // run the specified function
-    pub fn run(&self, query: RunQueryParams, body: &Value) -> Result<(), String> {
+    pub fn run(&self, query: RunQueryParams, body: &Value) -> Result<(), Error> {
         match self.funcs.iter().find(|f| f.slug() == query.fn_id) {
-            None => Err(format!("no function registered as ID: {}", query.fn_id)),
+            None => Err(Error::Basic(format!("no function registered as ID: {}", query.fn_id))),
             Some(func) => {
                 println!("Slug: {}", func.slug());
                 println!("Trigger: {:?}", func.trigger());
                 println!("Event: {:?}", func.event(&body["event"]));
 
                 match func.event(&body["event"]) {
-                    None => Err("failed to parse event".to_string()),
+                    None => Err(Error::Basic("failed to parse event".to_string())),
                     Some(evt) => (func.func)(Input {
                         event: evt,
                         events: vec![],

--- a/inngest/src/router/mod.rs
+++ b/inngest/src/router/mod.rs
@@ -83,14 +83,10 @@ where
     }
 
     // run the specified function
-    pub fn run(&self, query: RunQueryParams, body: &Value) -> Result<(), Error> {
+    pub fn run(&self, query: RunQueryParams, body: &Value) -> Result<Value, Error> {
         match self.funcs.iter().find(|f| f.slug() == query.fn_id) {
             None => Err(Error::Basic(format!("no function registered as ID: {}", query.fn_id))),
             Some(func) => {
-                println!("Slug: {}", func.slug());
-                println!("Trigger: {:?}", func.trigger());
-                println!("Event: {:?}", func.event(&body["event"]));
-
                 match func.event(&body["event"]) {
                     None => Err(Error::Basic("failed to parse event".to_string())),
                     Some(evt) => (func.func)(Input {
@@ -102,7 +98,6 @@ where
                             step_id: String::new(),
                         },
                     })
-                    .map(|_res| ()),
                 }
             }
         }

--- a/inngest/src/router/mod.rs
+++ b/inngest/src/router/mod.rs
@@ -3,7 +3,10 @@ pub mod axum;
 use std::collections::HashMap;
 
 use crate::{
-    event::InngestEvent, function::{Function, Input, InputCtx, ServableFn, Step, StepRetry, StepRuntime}, result::Error, sdk::Request
+    event::InngestEvent,
+    function::{Function, Input, InputCtx, ServableFn, Step, StepRetry, StepRuntime},
+    result::Error,
+    sdk::Request,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -85,21 +88,22 @@ where
     // run the specified function
     pub fn run(&self, query: RunQueryParams, body: &Value) -> Result<Value, Error> {
         match self.funcs.iter().find(|f| f.slug() == query.fn_id) {
-            None => Err(Error::Basic(format!("no function registered as ID: {}", query.fn_id))),
-            Some(func) => {
-                match func.event(&body["event"]) {
-                    None => Err(Error::Basic("failed to parse event".to_string())),
-                    Some(evt) => (func.func)(Input {
-                        event: evt,
-                        events: vec![],
-                        ctx: InputCtx {
-                            fn_id: String::new(),
-                            run_id: String::new(),
-                            step_id: String::new(),
-                        },
-                    })
-                }
-            }
+            None => Err(Error::Basic(format!(
+                "no function registered as ID: {}",
+                query.fn_id
+            ))),
+            Some(func) => match func.event(&body["event"]) {
+                None => Err(Error::Basic("failed to parse event".to_string())),
+                Some(evt) => (func.func)(Input {
+                    event: evt,
+                    events: vec![],
+                    ctx: InputCtx {
+                        fn_id: String::new(),
+                        run_id: String::new(),
+                        step_id: String::new(),
+                    },
+                }),
+            },
         }
     }
 }


### PR DESCRIPTION
- Add errors for retries, non retries and basic errors
- Change result to expect a `Value` type

Future changes can be made to provide a macro for `ok` that just wraps `json!()`.
This basically removes the need to declare a generic struct for Ok results that are bound by the `Serialize` trait.