### PR TITLE
move ops and step errors into control flow enum

### DIFF
--- a/inngest/src/handler.rs
+++ b/inngest/src/handler.rs
@@ -161,7 +161,7 @@ impl<T, E> Handler<T, E> {
                             }
                             Err(err) => {
                                 return Err(InngestError::Basic(format!(
-                                    "error seralizing step error: {}",
+                                    "error serializing step error: {}",
                                     err
                                 )));
                             }

--- a/inngest/src/handler.rs
+++ b/inngest/src/handler.rs
@@ -107,9 +107,6 @@ impl<T, E> Handler<T, E> {
         T: for<'de> Deserialize<'de> + Debug,
         E: Into<InngestError>,
     {
-        println!("running function: {}", query.fn_id);
-        println!("body: {:#?}", body);
-
         let data = match serde_json::from_value::<RunRequestBody<T>>(body.clone()) {
             Ok(res) => res,
             Err(err) => {

--- a/inngest/src/result.rs
+++ b/inngest/src/result.rs
@@ -54,12 +54,6 @@ pub(crate) enum FlowControlError {
     StepError(StepError),
 }
 
-impl FlowControlError {
-    pub fn new_step_generator(opcodes: impl Into<Vec<GeneratorOpCode>>) -> Self {
-        FlowControlError::StepGenerator(opcodes.into())
-    }
-}
-
 impl IntoResponse for InngestError {
     fn into_response(self) -> axum::response::Response {
         (

--- a/inngest/src/result.rs
+++ b/inngest/src/result.rs
@@ -8,6 +8,8 @@ use axum::{
 use serde::Serialize;
 use serde_json::{json, Value};
 
+use crate::step_tool::GeneratorOpCode;
+
 #[derive(Serialize)]
 pub struct SdkResponse {
     pub status: u16,
@@ -48,7 +50,14 @@ pub enum InngestError {
 
 #[derive(Debug)]
 pub(crate) enum FlowControlError {
-    StepGenerator,
+    StepGenerator(Vec<GeneratorOpCode>),
+    StepError(StepError),
+}
+
+impl FlowControlError {
+    pub fn new_step_generator(opcodes: impl Into<Vec<GeneratorOpCode>>) -> Self {
+        FlowControlError::StepGenerator(opcodes.into())
+    }
 }
 
 impl IntoResponse for InngestError {


### PR DESCRIPTION
Because we're already using enums to control flow, I was thinking we should move the generated state into the returned enum instead of mutating so that the overall control flow is more readable and testable. 

One of the main downsides to this approach is if we need to accumulate ops across more than one method call on the `Step.` Otherwise, think this makes the methods less mutable and more testable. Wdyt @darwin67? 

