### PR TITLE
fix: Default to Cloud mode following RFC

### DIFF
--- a/.github/workflows/convention.yml
+++ b/.github/workflows/convention.yml
@@ -1,0 +1,20 @@
+name: Convention Commit
+
+on:
+  pull_request:
+
+permissions:
+  pull-requests: read
+  statuses: write
+
+jobs:
+  lint:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    if: ${{ ! contains(github.head_ref, 'release/') }}
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          wip: true

--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ We currently support the following web frameworks:
 
 If there are other frameworks you like to see, feel free to submit an issue, or add to the [roadmap](https://roadmap.inngest.com/roadmap).
 
+## Supported features
+
+
+| Features              | Support            |
+|-----------------------|--------------------|
+| `step.run`            | :white_check_mark: |
+| `step.sleep`          | :white_check_mark: |
+| `step.wait_for_event` | :white_check_mark: |
+| `step.invoke`         | :white_check_mark: |
+| `step.send_event`     | :x:                |
+| CancelOn              | :x:                |
+| Failure handler       | :x:                |
+| Retry controls        | :white_check_mark: |
+| Middleware            | :x:                |
+| Connect               | :x:                |
+| AgentKit              | :x:                |
+
 ## Getting Started
 
 ``` toml

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -16,7 +16,6 @@ configMapGenerator:
 
       - INNGEST_SIGNING_KEY=REPLACE_SIGNING_KEY
       - INNGEST_EVENT_KEY=REPLACE_EVENT_KEY
-      - INNGEST_MODE=cloud
 
 resources:
   - namespace.yaml

--- a/inngest/src/client.rs
+++ b/inngest/src/client.rs
@@ -23,7 +23,7 @@ pub struct Inngest {
     pub(crate) event_api_origin: Option<String>,
     pub(crate) event_key: Option<String>,
     pub(crate) env: Option<String>,
-    dev: Option<String>,
+    pub(crate) dev: Option<String>,
     http: reqwest::Client,
 }
 

--- a/inngest/src/config.rs
+++ b/inngest/src/config.rs
@@ -1,7 +1,5 @@
 use std::env;
 
-use crate::handler::Kind;
-
 // client side
 const INNGEST_API_ORIGIN: &str = "INNGEST_API_ORIGIN";
 const INNGEST_EVENT_API_ORIGIN: &str = "INNGEST_EVENT_API_ORIGIN";
@@ -13,9 +11,6 @@ const INNGEST_DEV: &str = "INNGEST_DEV";
 const INNGEST_SIGNING_KEY: &str = "INNGEST_SIGNING_KEY";
 const INNGEST_SERVE_ORIGIN: &str = "INNGEST_SERVE_ORIGIN";
 const INNGEST_SERVE_PATH: &str = "INNGEST_SERVE_PATH";
-
-// optional
-const INNGEST_MODE: &str = "INNGEST_MODE";
 
 pub(crate) struct Config {}
 
@@ -50,16 +45,6 @@ impl Config {
 
     pub fn serve_path() -> Option<String> {
         Self::read_env_str(INNGEST_SERVE_PATH)
-    }
-
-    pub fn mode() -> Kind {
-        match Self::read_env_str(INNGEST_MODE) {
-            None => Kind::Dev,
-            Some(v) => match v.to_lowercase().as_str() {
-                "cloud" => Kind::Cloud,
-                _ => Kind::Dev,
-            },
-        }
     }
 
     // helper methods

--- a/inngest/src/handler.rs
+++ b/inngest/src/handler.rs
@@ -48,10 +48,12 @@ impl<T, E> Handler<T, E> {
         let serve_path = Config::serve_path();
         let mode = match client.dev.clone() {
             None => Kind::Cloud,
-            Some(v) => if v != "0" {
-                Kind::Dev
-            } else {
-                Kind::Cloud
+            Some(v) => {
+                if v != "0" {
+                    Kind::Dev
+                } else {
+                    Kind::Cloud
+                }
             }
         };
 

--- a/inngest/src/handler.rs
+++ b/inngest/src/handler.rs
@@ -46,7 +46,14 @@ impl<T, E> Handler<T, E> {
         let signing_key = Config::signing_key();
         let serve_origin = Config::serve_origin();
         let serve_path = Config::serve_path();
-        let mode = Config::mode();
+        let mode = match client.dev.clone() {
+            None => Kind::Cloud,
+            Some(v) => if v != "0" {
+                Kind::Dev
+            } else {
+                Kind::Cloud
+            }
+        };
 
         Handler {
             signing_key,


### PR DESCRIPTION
Based on SDK spec, the SDK should always be defaulting to `cloud` mode.
And should only run in dev mode when `INNGEST_DEV` is provided.