### PR TITLE
refactor(handler): support mixed function types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,14 @@ Use standard conventional commit formatting such as `fix(promapi): handle empty 
 
 ## Development Commands
 
+- commit in logical sections whenever possible to make each commit as reviewable by its own as possible
+- run `make lint` and tests targeting the changes to confirm expected results and there are no build failures
+
+### Tests
+
+- Always add tests to verify behavior
+- When fixing bugs, make sure to create a test case with that ideal outcome that fails with existing behavior before proceeding with a fix
+
 ### Building and Running
 
 - `cargo check -p inngest` checks the crate without running tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Use standard conventional commit formatting such as `fix(promapi): handle empty 
 
 - commit in logical sections whenever possible to make each commit as reviewable by its own as possible
 - run `make lint` and tests targeting the changes to confirm expected results and there are no build failures
+- add comments to public structs, traits and functions so it materializes in cargo docs
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -59,17 +59,19 @@ inngest = "0.1"
 
 ```rs
 use axum::{
-  routing::{get, put},
+  routing::get,
   Router
 };
+use tokio::net::TcpListener;
 
 #[tokio::main]
 async fn main() {
     let client = Inngest::new("rust-app");
     let mut inngest_handler = Handler::new(&client);
     inngest_handler.register_fns(vec![
-         hello_fn(&client)
-     ]);
+         hello_fn(&client).into(),
+         step_run_fn(&client).into(),
+    ]);
 
     let inngest_state = Arc::new(inngest_handler);
 
@@ -77,30 +79,35 @@ async fn main() {
         .route("/", get(|| async { "OK!\n" }))
         .route(
             "/api/inngest",
-            put(serve::axum::register).post(serve::axum::invoke),
+            get(serve::axum::introspect)
+                .put(serve::axum::register)
+                .post(serve::axum::invoke),
         )
         .with_state(inngest_state);
 
-    let addr = "[::]:3000".parse::<std::net::SocketAddr>().unwrap();
+    let listener = TcpListener::bind("[::]:3000").await.unwrap();
 
-    // run it with hyper on localhost:3000
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
+    axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-#[serde(untagged)]
-enum Data {
-    Hello { msg: String },
+struct HelloEventData {
+    msg: String,
 }
 
-fn hello_fn(client: &Inngest) -> ServableFn<Data, Error> {
+#[derive(Serialize, Deserialize, Debug)]
+struct StepRunEventData {
+    name: String,
+    data: u8,
+}
+
+fn hello_fn(client: &Inngest) -> ServableFn<HelloEventData, Error> {
     client.create_function(
         FunctionOpts::new("hello-func").name("Hello func"),
         Trigger::event("test/hello"),
-        |input: Input<Data>, step: StepTool| async move {
+        |input: Input<HelloEventData>, step: StepTool| async move {
             let step_res = into_dev_result!(
                 step.run("fallible-step-function", || async move {
                     // if even, fail
@@ -130,4 +137,16 @@ fn hello_fn(client: &Inngest) -> ServableFn<Data, Error> {
         },
     )
 }
+
+fn step_run_fn(client: &Inngest) -> ServableFn<StepRunEventData, Error> {
+    client.create_function(
+        FunctionOpts::new("step-run").name("Step run"),
+        Trigger::event("test/step-run"),
+        |_input: Input<StepRunEventData>, _step: StepTool| async move {
+            Ok(json!({ "step": true }))
+        },
+    )
+}
 ```
+
+The handler can register functions with different event payload types on the same app. When batching them with `register_fns(...)`, convert each function with `.into()` as shown above.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ If there are other frameworks you like to see, feel free to submit an issue, or 
 | Retry controls        | :white_check_mark: |
 | Middleware            | :x:                |
 | Connect               | :x:                |
-| AgentKit              | :x:                |
 
 ## Getting Started
 

--- a/inngest/examples/axum/main.rs
+++ b/inngest/examples/axum/main.rs
@@ -19,13 +19,11 @@ async fn main() {
 
     let client = Inngest::new("rust-dev");
     let mut inngest_handler = Handler::new(&client);
-    inngest_handler.register_fns(vec![
-        dummy_fn(&client),
-        hello_fn(&client),
-        step_run(&client),
-        fallible_step_run(&client),
-        incorrectly_propagates_error(&client),
-    ]);
+    inngest_handler.register_fn(dummy_fn(&client));
+    inngest_handler.register_fn(hello_fn(&client));
+    inngest_handler.register_fn(step_run(&client));
+    inngest_handler.register_fn(fallible_step_run(&client));
+    inngest_handler.register_fn(incorrectly_propagates_error(&client));
 
     let inngest_state = Arc::new(inngest_handler);
 
@@ -85,19 +83,29 @@ impl From<UserLandError> for inngest::result::Error {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-#[serde(untagged)]
-enum Data {
-    TestData { name: String, data: u8 },
-    Hello { msg: String },
+struct DummyEventData {
+    name: String,
+    data: u8,
 }
 
-fn dummy_fn(client: &Inngest) -> ServableFn<Data, Error> {
+#[derive(Serialize, Deserialize, Debug)]
+struct HelloEventData {
+    msg: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct StepRunEventData {
+    name: String,
+    data: u8,
+}
+
+fn dummy_fn(client: &Inngest) -> ServableFn<DummyEventData, Error> {
     let invoke_id = fallible_step_run(client).slug();
 
     client.create_function(
         FunctionOpts::new("dummy-func").name("Dummy func"),
         Trigger::event("test/event"),
-        move |_input: Input<Data>, step: StepTool| {
+        move |_input: Input<DummyEventData>, step: StepTool| {
             let function_id = invoke_id.clone();
 
             async move {
@@ -131,11 +139,11 @@ fn dummy_fn(client: &Inngest) -> ServableFn<Data, Error> {
     )
 }
 
-fn hello_fn(client: &Inngest) -> ServableFn<Data, Error> {
+fn hello_fn(client: &Inngest) -> ServableFn<HelloEventData, Error> {
     client.create_function(
         FunctionOpts::new("hello-func").name("Hello func"),
         Trigger::event("test/hello"),
-        |input: Input<Data>, step: StepTool| async move {
+        |input: Input<HelloEventData>, step: StepTool| async move {
             let step_res = into_dev_result!(
                 step.run("fallible-step-function", || async move {
                     // if even, fail
@@ -167,7 +175,10 @@ fn hello_fn(client: &Inngest) -> ServableFn<Data, Error> {
     )
 }
 
-async fn call_some_step_function(_input: Input<Data>, step: StepTool) -> Result<Value, Error> {
+async fn call_some_step_function(
+    _input: Input<StepRunEventData>,
+    step: StepTool,
+) -> Result<Value, Error> {
     let some_captured_variable = "captured".to_string();
 
     let step_res = step
@@ -184,7 +195,7 @@ async fn call_some_step_function(_input: Input<Data>, step: StepTool) -> Result<
     Ok(step_res)
 }
 
-fn step_run(client: &Inngest) -> ServableFn<Data, Error> {
+fn step_run(client: &Inngest) -> ServableFn<StepRunEventData, Error> {
     client.create_function(
         FunctionOpts::new("step-run").name("Step run"),
         Trigger::event("test/step-run"),
@@ -192,11 +203,11 @@ fn step_run(client: &Inngest) -> ServableFn<Data, Error> {
     )
 }
 
-fn incorrectly_propagates_error(client: &Inngest) -> ServableFn<Data, Error> {
+fn incorrectly_propagates_error(client: &Inngest) -> ServableFn<StepRunEventData, Error> {
     client.create_function(
         FunctionOpts::new("step-run").name("Step run"),
         Trigger::event("test/step-run-incorrect"),
-        |_input: Input<Data>, step: StepTool| async move {
+        |_input: Input<StepRunEventData>, step: StepTool| async move {
             let some_captured_variable = "captured".to_string();
 
             let res = step
@@ -218,11 +229,11 @@ fn incorrectly_propagates_error(client: &Inngest) -> ServableFn<Data, Error> {
     )
 }
 
-fn fallible_step_run(client: &Inngest) -> ServableFn<Data, Error> {
+fn fallible_step_run(client: &Inngest) -> ServableFn<StepRunEventData, Error> {
     client.create_function(
         FunctionOpts::new("fallible-step-run").name("Fallible Step run"),
         Trigger::event("test/step-run-fallible"),
-        |input: Input<Data>, step: StepTool| async move {
+        |input: Input<StepRunEventData>, step: StepTool| async move {
             let step_res = into_dev_result!(
                 step.run("fallible-step-function", || async move {
                     // if even, fail

--- a/inngest/examples/axum/main.rs
+++ b/inngest/examples/axum/main.rs
@@ -19,11 +19,13 @@ async fn main() {
 
     let client = Inngest::new("rust-dev");
     let mut inngest_handler = Handler::new(&client);
-    inngest_handler.register_fn(dummy_fn(&client));
-    inngest_handler.register_fn(hello_fn(&client));
-    inngest_handler.register_fn(step_run(&client));
-    inngest_handler.register_fn(fallible_step_run(&client));
-    inngest_handler.register_fn(incorrectly_propagates_error(&client));
+    inngest_handler.register_fns(vec![
+        dummy_fn(&client).into(),
+        hello_fn(&client).into(),
+        step_run(&client).into(),
+        fallible_step_run(&client).into(),
+        incorrectly_propagates_error(&client).into(),
+    ]);
 
     let inngest_state = Arc::new(inngest_handler);
 

--- a/inngest/examples/send_events/main.rs
+++ b/inngest/examples/send_events/main.rs
@@ -7,12 +7,6 @@ struct Data {
     bar: u8,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
-struct TestEvent<T> {
-    name: String,
-    data: T,
-}
-
 #[tokio::main]
 async fn main() {
     let client = Inngest::new("send-events").event_key("yolo");

--- a/inngest/src/client.rs
+++ b/inngest/src/client.rs
@@ -163,7 +163,7 @@ impl Inngest {
     }
 
     fn inngest_evt_api_key(&self) -> String {
-        if let Some(_) = self.dev.clone() {
+        if self.dev.is_some() {
             return "test".to_string();
         }
 

--- a/inngest/src/handler.rs
+++ b/inngest/src/handler.rs
@@ -648,6 +648,7 @@ mod tests {
     use crate::function::ServableFn;
     use axum::http::HeaderMap;
     use serde::{Deserialize, Serialize};
+    use std::collections::HashSet;
 
     #[derive(Debug, Deserialize, Serialize)]
     struct FirstEvent {
@@ -737,5 +738,178 @@ mod tests {
             .expect("second function should run");
         assert_eq!(second_response.status, 200);
         assert_eq!(second_response.body, json!({ "count": 42 }));
+    }
+
+    #[tokio::test]
+    async fn handler_dispatches_functions_registered_via_mixed_apis() {
+        let client = Inngest::new("test-app");
+        let mut handler = Handler::new(&client);
+
+        let first_fn: ServableFn<FirstEvent, Error> = client.create_function(
+            FunctionOpts::new("first"),
+            Trigger::event("test/first"),
+            |input: Input<FirstEvent>, _step| async move {
+                Ok(json!({ "message": input.event.data.message }))
+            },
+        );
+        let first_fn_id = first_fn.slug();
+        handler.register_fn(first_fn);
+
+        let second_fn: ServableFn<SecondEvent, Error> = client.create_function(
+            FunctionOpts::new("second"),
+            Trigger::event("test/second"),
+            |input: Input<SecondEvent>, _step| async move {
+                Ok(json!({ "count": input.event.data.count }))
+            },
+        );
+        let second_fn_id = second_fn.slug();
+        handler.register_fns(vec![second_fn.into()]);
+
+        let headers = Headers::from(HeaderMap::new());
+
+        let first_response = handler
+            .run(
+                &headers,
+                &RunQueryParams { fn_id: first_fn_id },
+                &event_body("test/first", json!({ "message": "hello" })).to_string(),
+                &event_body("test/first", json!({ "message": "hello" })),
+            )
+            .await
+            .expect("first function should run");
+        assert_eq!(first_response.body, json!({ "message": "hello" }));
+
+        let second_response = handler
+            .run(
+                &headers,
+                &RunQueryParams {
+                    fn_id: second_fn_id,
+                },
+                &event_body("test/second", json!({ "count": 42 })).to_string(),
+                &event_body("test/second", json!({ "count": 42 })),
+            )
+            .await
+            .expect("second function should run");
+        assert_eq!(second_response.body, json!({ "count": 42 }));
+    }
+
+    #[tokio::test]
+    async fn handler_returns_error_for_unknown_function_id() {
+        let client = Inngest::new("test-app");
+        let handler = Handler::new(&client);
+        let headers = Headers::from(HeaderMap::new());
+        let body = event_body("test/first", json!({ "message": "hello" }));
+
+        let error = match handler
+            .run(
+                &headers,
+                &RunQueryParams {
+                    fn_id: "test-app-missing".to_string(),
+                },
+                &body.to_string(),
+                &body,
+            )
+            .await
+        {
+            Ok(_) => panic!("missing function id should fail"),
+            Err(error) => error,
+        };
+
+        match error {
+            Error::Dev(crate::result::DevError::Basic(message)) => {
+                assert!(message.contains("no function registered as ID"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn handler_returns_error_for_mismatched_event_payload() {
+        let client = Inngest::new("test-app");
+        let mut handler = Handler::new(&client);
+
+        let first_fn: ServableFn<FirstEvent, Error> = client.create_function(
+            FunctionOpts::new("first"),
+            Trigger::event("test/first"),
+            |input: Input<FirstEvent>, _step| async move {
+                Ok(json!({ "message": input.event.data.message }))
+            },
+        );
+        let first_fn_id = first_fn.slug();
+        handler.register_fn(first_fn);
+
+        let headers = Headers::from(HeaderMap::new());
+        let body = event_body("test/first", json!({ "count": 42 }));
+
+        let error = match handler
+            .run(
+                &headers,
+                &RunQueryParams { fn_id: first_fn_id },
+                &body.to_string(),
+                &body,
+            )
+            .await
+        {
+            Ok(_) => panic!("mismatched payload should fail"),
+            Err(error) => error,
+        };
+
+        match error {
+            Error::Dev(crate::result::DevError::Basic(message)) => {
+                assert!(message.contains("error parsing run request"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sync_payload_includes_all_registered_functions() {
+        let client = Inngest::new("test-app");
+        let mut handler = Handler::new(&client);
+
+        let first_fn: ServableFn<FirstEvent, Error> = client.create_function(
+            FunctionOpts::new("first"),
+            Trigger::event("test/first"),
+            |input: Input<FirstEvent>, _step| async move {
+                Ok(json!({ "message": input.event.data.message }))
+            },
+        );
+        let second_fn: ServableFn<SecondEvent, Error> = client.create_function(
+            FunctionOpts::new("second"),
+            Trigger::event("test/second"),
+            |input: Input<SecondEvent>, _step| async move {
+                Ok(json!({ "count": input.event.data.count }))
+            },
+        );
+
+        handler.register_fns(vec![first_fn.into(), second_fn.into()]);
+
+        let payload = handler.sync_payload(&Headers::from(HeaderMap::new()), "axum");
+        let function_ids: HashSet<String> = payload
+            .functions
+            .into_iter()
+            .map(|function| function.id)
+            .collect();
+
+        assert_eq!(payload.app_name, "test-app");
+        assert_eq!(payload.framework, "axum");
+        assert_eq!(function_ids.len(), 2);
+        assert!(function_ids.contains("test-app-first"));
+        assert!(function_ids.contains("test-app-second"));
+    }
+
+    fn event_body(name: &str, data: Value) -> Value {
+        json!({
+            "ctx": { "attempt": 1, "env": "test", "run_id": "run-1" },
+            "event": {
+                "id": null,
+                "name": name,
+                "data": data,
+                "ts": null,
+                "v": null
+            },
+            "events": [],
+            "use_api": false,
+            "steps": {}
+        })
     }
 }

--- a/inngest/src/handler.rs
+++ b/inngest/src/handler.rs
@@ -1,17 +1,18 @@
-use std::{collections::HashMap, fmt::Debug, panic::AssertUnwindSafe};
+use std::{collections::HashMap, panic::AssertUnwindSafe, sync::Arc};
 
-use futures::FutureExt;
+use futures::{future::BoxFuture, FutureExt};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha1::Digest;
 use sha2::Sha256;
+use slug::slugify;
 
 use crate::{
     basic_error,
     client::{self, Inngest},
     config::Config,
-    event::Event,
-    function::{Function, Input, InputCtx, ServableFn},
+    event::{Event, InngestEvent},
+    function::{Function, FunctionOpts, Input, InputCtx, ServableFn, Trigger},
     header::Headers,
     result::{Error, FlowControlVariant, SdkResponse},
     sdk::Request,
@@ -19,13 +20,173 @@ use crate::{
     step_tool::Step as StepTool,
 };
 
-pub struct Handler<T: 'static, E> {
+type DynamicFn =
+    dyn Fn(String, Value) -> BoxFuture<'static, Result<SdkResponse, Error>> + Send + Sync + 'static;
+
+struct DynamicServableFn {
+    app_id: String,
+    opts: FunctionOpts,
+    trigger: Trigger,
+    func: Box<DynamicFn>,
+}
+
+impl DynamicServableFn {
+    fn slug(&self) -> String {
+        format!("{}-{}", &self.app_id, slugify(self.opts.id.clone()))
+    }
+
+    fn function(&self, serve_origin: &str, serve_path: &str) -> Function {
+        let id = self.slug();
+        let name = match self.opts.name.clone() {
+            Some(name) => name,
+            None => id.clone(),
+        };
+
+        let mut steps = HashMap::new();
+        steps.insert(
+            "step".to_string(),
+            crate::function::Step {
+                id: "step".to_string(),
+                name: "step".to_string(),
+                runtime: crate::function::StepRuntime {
+                    url: format!("{}{}?fnId={}&step=step", serve_origin, serve_path, &id),
+                    method: "http".to_string(),
+                },
+                retries: crate::function::StepRetry {
+                    attempts: self.opts.retries,
+                },
+            },
+        );
+
+        Function {
+            id,
+            name,
+            triggers: vec![self.trigger.clone()],
+            steps,
+        }
+    }
+
+    async fn run(&self, fn_id: String, body: Value) -> Result<SdkResponse, Error> {
+        (self.func)(fn_id, body).await
+    }
+}
+
+impl<T, E> From<ServableFn<T, E>> for DynamicServableFn
+where
+    T: InngestEvent + Send,
+    E: Into<Error> + 'static,
+{
+    fn from(func: ServableFn<T, E>) -> Self {
+        let ServableFn {
+            app_id,
+            opts,
+            trigger,
+            func,
+        } = func;
+        let func = Arc::new(func);
+
+        Self {
+            app_id,
+            opts,
+            trigger,
+            func: Box::new(move |fn_id, body| {
+                let step_func = Arc::clone(&func);
+
+                async move {
+                    let data = match serde_json::from_value::<RunRequestBody<T>>(body.clone()) {
+                        Ok(res) => res,
+                        Err(err) => {
+                            println!("ERROR: {:?}", err);
+                            println!("BODY: {:#?}", &body);
+                            let msg = basic_error!("error parsing run request: {}", err);
+                            return Err(msg);
+                        }
+                    };
+
+                    if data.use_api {}
+
+                    let input = Input {
+                        event: data.event,
+                        events: data.events,
+                        ctx: InputCtx {
+                            env: data.ctx.env.clone(),
+                            fn_id,
+                            run_id: data.ctx.run_id.clone(),
+                            step_id: "step".to_string(),
+                            attempt: data.ctx.attempt,
+                        },
+                    };
+
+                    let step_tool = StepTool::new(&data.steps);
+
+                    match std::panic::catch_unwind(AssertUnwindSafe(|| {
+                        (step_func.as_ref())(input, step_tool.clone())
+                    })) {
+                        Ok(fut) => match AssertUnwindSafe(fut).catch_unwind().await {
+                            Ok(v) => match v {
+                                Ok(v) => Ok(SdkResponse {
+                                    status: 200,
+                                    body: v,
+                                }),
+                                Err(err) => match err.into() {
+                                    Error::Interrupt(mut flow) => {
+                                        flow.acknowledge();
+                                        match flow.variant {
+                                            FlowControlVariant::StepGenerator => {
+                                                let (status, body) = if step_tool.error().is_some() {
+                                                    match serde_json::to_value(&step_tool.error()) {
+                                                        Ok(v) => (500, v),
+                                                        Err(err) => {
+                                                            return Err(basic_error!(
+                                                                "error seralizing step error: {}",
+                                                                err
+                                                            ));
+                                                        }
+                                                    }
+                                                } else if step_tool.genop().len() > 0 {
+                                                    match serde_json::to_value(&step_tool.genop()) {
+                                                        Ok(v) => (206, v),
+                                                        Err(err) => {
+                                                            return Err(basic_error!(
+                                                                "error serializing step response: {}",
+                                                                err
+                                                            ));
+                                                        }
+                                                    }
+                                                } else {
+                                                    (206, json!("null"))
+                                                };
+                                                Ok(SdkResponse { status, body })
+                                            }
+                                        }
+                                    }
+                                    other => Err(other),
+                                },
+                            },
+                            Err(panic_err) => Ok(SdkResponse {
+                                status: 500,
+                                body: Value::String(format!("panic: {:?}", panic_err)),
+                            }),
+                        },
+                        Err(panic_err) => Ok(SdkResponse {
+                            status: 500,
+                            body: Value::String(format!("panic: {:?}", panic_err)),
+                        }),
+                    }
+                }
+                .boxed()
+            }),
+        }
+    }
+}
+
+pub struct Handler {
     inngest: Inngest,
     signing_key: Option<String>,
     // TODO: signing_key_fallback
     serve_origin: Option<String>,
     serve_path: Option<String>,
-    funcs: HashMap<String, ServableFn<T, E>>,
+    funcs: HashMap<String, DynamicServableFn>,
     mode: Kind,
 }
 
@@ -41,7 +202,7 @@ pub struct SyncQueryParams {
     deploy_id: Option<String>,
 }
 
-impl<T, E> Handler<T, E> {
+impl Handler {
     pub fn new(client: &Inngest) -> Self {
         let signing_key = Config::signing_key();
         let serve_origin = Config::serve_origin();
@@ -82,13 +243,22 @@ impl<T, E> Handler<T, E> {
         self
     }
 
-    pub fn register_fn(&mut self, func: ServableFn<T, E>) {
+    pub fn register_fn<T, E>(&mut self, func: ServableFn<T, E>)
+    where
+        T: InngestEvent + Send,
+        E: Into<Error> + 'static,
+    {
+        let func = DynamicServableFn::from(func);
         self.funcs.insert(func.slug(), func);
     }
 
-    pub fn register_fns(&mut self, funcs: Vec<ServableFn<T, E>>) {
+    pub fn register_fns<T, E>(&mut self, funcs: Vec<ServableFn<T, E>>)
+    where
+        T: InngestEvent + Send,
+        E: Into<Error> + 'static,
+    {
         for f in funcs {
-            self.funcs.insert(f.slug(), f);
+            self.register_fn(f);
         }
     }
 
@@ -330,11 +500,7 @@ impl<T, E> Handler<T, E> {
         query: &RunQueryParams,
         raw_body: &str,
         body: &Value,
-    ) -> Result<SdkResponse, Error>
-    where
-        T: for<'de> Deserialize<'de> + Debug,
-        E: Into<Error>,
-    {
+    ) -> Result<SdkResponse, Error> {
         let sig = headers.signature();
         let kind = headers.server_kind();
         if kind == Kind::Cloud && sig.is_none() {
@@ -346,20 +512,6 @@ impl<T, E> Handler<T, E> {
             _ = self.verify_signature(&sig, raw_body)?;
         }
 
-        let data = match serde_json::from_value::<RunRequestBody<T>>(body.clone()) {
-            Ok(res) => res,
-            Err(err) => {
-                println!("ERROR: {:?}", err);
-                println!("BODY: {:#?}", &body);
-                // TODO: need to surface this error better
-                let msg = basic_error!("error parsing run request: {}", err);
-                return Err(msg);
-            }
-        };
-
-        // TODO: retrieve data from API on flag
-        if data.use_api {}
-
         // find the specified function
         let Some(func) = self.funcs.get(&query.fn_id) else {
             return Err(basic_error!(
@@ -368,78 +520,7 @@ impl<T, E> Handler<T, E> {
             ));
         };
 
-        let input = Input {
-            event: data.event,
-            events: data.events,
-            ctx: InputCtx {
-                env: data.ctx.env.clone(),
-                fn_id: query.fn_id.clone(),
-                run_id: data.ctx.run_id.clone(),
-                step_id: "step".to_string(),
-                attempt: data.ctx.attempt,
-            },
-        };
-
-        let step_tool = StepTool::new(&data.steps);
-
-        match std::panic::catch_unwind(AssertUnwindSafe(|| (func.func)(input, step_tool.clone()))) {
-            Ok(fut) => {
-                match AssertUnwindSafe(fut).catch_unwind().await {
-                    Ok(v) => match v {
-                        Ok(v) => Ok(SdkResponse {
-                            status: 200,
-                            body: v,
-                        }),
-                        Err(err) => match err.into() {
-                            Error::Interrupt(mut flow) => {
-                                flow.acknowledge();
-                                match flow.variant {
-                                    FlowControlVariant::StepGenerator => {
-                                        let (status, body) = if step_tool.error().is_some() {
-                                            match serde_json::to_value(&step_tool.error()) {
-                                                Ok(v) => {
-                                                    // TODO: check current attempts and see if it can retry or not
-                                                    (500, v)
-                                                }
-                                                Err(err) => {
-                                                    return Err(basic_error!(
-                                                        "error seralizing step error: {}",
-                                                        err
-                                                    ));
-                                                }
-                                            }
-                                        } else if step_tool.genop().len() > 0 {
-                                            // TODO: only expecting one for now, will need to handle multiple
-                                            match serde_json::to_value(&step_tool.genop()) {
-                                                Ok(v) => (206, v),
-                                                Err(err) => {
-                                                    return Err(basic_error!(
-                                                        "error serializing step response: {}",
-                                                        err
-                                                    ));
-                                                }
-                                            }
-                                        } else {
-                                            (206, json!("null"))
-                                        };
-                                        Ok(SdkResponse { status, body })
-                                    }
-                                }
-                            }
-                            other => Err(other),
-                        },
-                    },
-                    Err(panic_err) => Ok(SdkResponse {
-                        status: 500,
-                        body: Value::String(format!("panic: {:?}", panic_err)),
-                    }),
-                }
-            }
-            Err(panic_err) => Ok(SdkResponse {
-                status: 500,
-                body: Value::String(format!("panic: {:?}", panic_err)),
-            }),
-        }
+        func.run(query.fn_id.clone(), body.clone()).await
     }
     // run the function
 }
@@ -556,4 +637,102 @@ pub struct InngestSyncError {
 pub struct InngestSyncSuccess {
     ok: bool,
     modified: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::function::ServableFn;
+    use axum::http::HeaderMap;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Deserialize, Serialize)]
+    struct FirstEvent {
+        message: String,
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    struct SecondEvent {
+        count: u32,
+    }
+
+    #[tokio::test]
+    async fn handler_dispatches_functions_with_different_event_types() {
+        let client = Inngest::new("test-app");
+        let mut handler = Handler::new(&client);
+
+        let first_fn: ServableFn<FirstEvent, Error> = client.create_function(
+            FunctionOpts::new("first"),
+            Trigger::event("test/first"),
+            |input: Input<FirstEvent>, _step| async move {
+                Ok(json!({ "message": input.event.data.message }))
+            },
+        );
+        let first_fn_id = first_fn.slug();
+        handler.register_fn(first_fn);
+
+        let second_fn: ServableFn<SecondEvent, Error> = client.create_function(
+            FunctionOpts::new("second"),
+            Trigger::event("test/second"),
+            |input: Input<SecondEvent>, _step| async move {
+                Ok(json!({ "count": input.event.data.count }))
+            },
+        );
+        let second_fn_id = second_fn.slug();
+        handler.register_fn(second_fn);
+
+        let headers = Headers::from(HeaderMap::new());
+
+        let first_body = json!({
+            "ctx": { "attempt": 1, "env": "test", "run_id": "run-1" },
+            "event": {
+                "id": null,
+                "name": "test/first",
+                "data": { "message": "hello" },
+                "ts": null,
+                "v": null
+            },
+            "events": [],
+            "use_api": false,
+            "steps": {}
+        });
+        let first_response = handler
+            .run(
+                &headers,
+                &RunQueryParams { fn_id: first_fn_id },
+                &first_body.to_string(),
+                &first_body,
+            )
+            .await
+            .expect("first function should run");
+        assert_eq!(first_response.status, 200);
+        assert_eq!(first_response.body, json!({ "message": "hello" }));
+
+        let second_body = json!({
+            "ctx": { "attempt": 1, "env": "test", "run_id": "run-2" },
+            "event": {
+                "id": null,
+                "name": "test/second",
+                "data": { "count": 42 },
+                "ts": null,
+                "v": null
+            },
+            "events": [],
+            "use_api": false,
+            "steps": {}
+        });
+        let second_response = handler
+            .run(
+                &headers,
+                &RunQueryParams {
+                    fn_id: second_fn_id,
+                },
+                &second_body.to_string(),
+                &second_body,
+            )
+            .await
+            .expect("second function should run");
+        assert_eq!(second_response.status, 200);
+        assert_eq!(second_response.body, json!({ "count": 42 }));
+    }
 }

--- a/inngest/src/handler.rs
+++ b/inngest/src/handler.rs
@@ -71,6 +71,14 @@ impl DynamicServableFn {
     }
 }
 
+pub struct RegisteredFn(DynamicServableFn);
+
+impl RegisteredFn {
+    fn into_dynamic(self) -> DynamicServableFn {
+        self.0
+    }
+}
+
 impl<T, E> From<ServableFn<T, E>> for DynamicServableFn
 where
     T: InngestEvent + Send,
@@ -180,6 +188,16 @@ where
     }
 }
 
+impl<T, E> From<ServableFn<T, E>> for RegisteredFn
+where
+    T: InngestEvent + Send,
+    E: Into<Error> + 'static,
+{
+    fn from(func: ServableFn<T, E>) -> Self {
+        Self(DynamicServableFn::from(func))
+    }
+}
+
 pub struct Handler {
     inngest: Inngest,
     signing_key: Option<String>,
@@ -252,13 +270,13 @@ impl Handler {
         self.funcs.insert(func.slug(), func);
     }
 
-    pub fn register_fns<T, E>(&mut self, funcs: Vec<ServableFn<T, E>>)
+    pub fn register_fns<I>(&mut self, funcs: I)
     where
-        T: InngestEvent + Send,
-        E: Into<Error> + 'static,
+        I: IntoIterator<Item = RegisteredFn>,
     {
         for f in funcs {
-            self.register_fn(f);
+            let func = f.into_dynamic();
+            self.funcs.insert(func.slug(), func);
         }
     }
 
@@ -654,7 +672,6 @@ mod tests {
             },
         );
         let first_fn_id = first_fn.slug();
-        handler.register_fn(first_fn);
 
         let second_fn: ServableFn<SecondEvent, Error> = client.create_function(
             FunctionOpts::new("second"),
@@ -664,7 +681,8 @@ mod tests {
             },
         );
         let second_fn_id = second_fn.slug();
-        handler.register_fn(second_fn);
+
+        handler.register_fns(vec![first_fn.into(), second_fn.into()]);
 
         let headers = Headers::from(HeaderMap::new());
 

--- a/inngest/src/handler.rs
+++ b/inngest/src/handler.rs
@@ -103,7 +103,7 @@ where
                         }
                     };
 
-                    if data.use_api {}
+                    let _ = data._use_api;
 
                     let input = Input {
                         event: data.event,
@@ -134,7 +134,7 @@ where
                                         match flow.variant {
                                             FlowControlVariant::StepGenerator => {
                                                 let (status, body) = if step_tool.error().is_some() {
-                                                    match serde_json::to_value(&step_tool.error()) {
+                                                    match serde_json::to_value(step_tool.error()) {
                                                         Ok(v) => (500, v),
                                                         Err(err) => {
                                                             return Err(basic_error!(
@@ -143,8 +143,8 @@ where
                                                             ));
                                                         }
                                                     }
-                                                } else if step_tool.genop().len() > 0 {
-                                                    match serde_json::to_value(&step_tool.genop()) {
+                                                } else if !step_tool.genop().is_empty() {
+                                                    match serde_json::to_value(step_tool.genop()) {
                                                         Ok(v) => (206, v),
                                                         Err(err) => {
                                                             return Err(basic_error!(
@@ -295,7 +295,7 @@ impl Handler {
             ));
         };
 
-        let signature = Signature::new(&key).sig(&sig).body(raw_body);
+        let signature = Signature::new(&key).sig(sig).body(raw_body);
         signature.verify(false)
     }
 
@@ -315,7 +315,7 @@ impl Handler {
         let mut authentication_succeeded: Option<bool> = None;
 
         match self.mode {
-            Kind::Dev => Ok(IntrospectResult::Unauthenticated(
+            Kind::Dev => Ok(IntrospectResult::Unauthenticated(Box::new(
                 IntrospectUnauthedResult {
                     authentication_succeeded,
                     extra: None,
@@ -326,11 +326,11 @@ impl Handler {
                     mode: Kind::Dev,
                     schema_version,
                 },
-            )),
+            ))),
 
             Kind::Cloud => {
                 if let Some(sig) = headers.signature() {
-                    if let Ok(_) = self.verify_signature(&sig, raw_body) {
+                    if self.verify_signature(&sig, raw_body).is_ok() {
                         let api_origin = match self.inngest.api_origin.clone() {
                             Some(origin) => origin,
                             None => client::API_ORIGIN.to_string(),
@@ -343,42 +343,41 @@ impl Handler {
 
                         let event_key_hash = self.hash_key(self.inngest.event_key.clone());
                         let signing_key_hash = if let Some(key) = self.signing_key.clone() {
-                            match Signature::new(&key).hash() {
-                                Ok(hash) => Some(hash),
-                                Err(_) => None,
-                            }
+                            Signature::new(&key).hash().ok()
                         } else {
                             None
                         };
 
-                        return Ok(IntrospectResult::Authenticated(IntrospectAuthedResult {
-                            app_id: self.inngest.app_id(),
-                            api_origin,
-                            event_api_origin,
-                            event_key_hash,
-                            authentication_succeeded: true,
-                            env: None, // TODO
-                            extra: None,
-                            framework: framework.to_string(),
-                            function_count,
-                            has_event_key,
-                            has_signing_key,
-                            has_signing_key_fallback,
-                            mode: Kind::Cloud,
-                            schema_version,
-                            sdk_language: "rust".to_string(),
-                            sdk_version: env!("CARGO_PKG_VERSION").to_string(),
-                            serve_origin: self.serve_origin.clone(),
-                            serve_path: self.serve_path.clone(),
-                            signing_key_hash,
-                            signing_key_fallback_hash: None, // TODO
-                        }));
+                        return Ok(IntrospectResult::Authenticated(Box::new(
+                            IntrospectAuthedResult {
+                                app_id: self.inngest.app_id(),
+                                api_origin,
+                                event_api_origin,
+                                event_key_hash,
+                                authentication_succeeded: true,
+                                env: None, // TODO
+                                extra: None,
+                                framework: framework.to_string(),
+                                function_count,
+                                has_event_key,
+                                has_signing_key,
+                                has_signing_key_fallback,
+                                mode: Kind::Cloud,
+                                schema_version,
+                                sdk_language: "rust".to_string(),
+                                sdk_version: env!("CARGO_PKG_VERSION").to_string(),
+                                serve_origin: self.serve_origin.clone(),
+                                serve_path: self.serve_path.clone(),
+                                signing_key_hash,
+                                signing_key_fallback_hash: None, // TODO
+                            },
+                        )));
                     };
                     // mark it as false
                     authentication_succeeded = Some(false);
                 }
 
-                Ok(IntrospectResult::Unauthenticated(
+                Ok(IntrospectResult::Unauthenticated(Box::new(
                     IntrospectUnauthedResult {
                         authentication_succeeded,
                         extra: None,
@@ -389,7 +388,7 @@ impl Handler {
                         mode: Kind::Cloud,
                         schema_version,
                     },
-                ))
+                )))
             }
         }
     }
@@ -420,8 +419,8 @@ impl Handler {
         let app_id = self.inngest.app_id();
         let functions: Vec<Function> = self
             .funcs
-            .iter()
-            .map(|(_, f)| f.function(&self.app_serve_origin(headers), &self.app_serve_path()))
+            .values()
+            .map(|f| f.function(&self.app_serve_origin(headers), &self.app_serve_path()))
             .collect();
 
         Request {
@@ -454,7 +453,7 @@ impl Handler {
             .json(&req);
 
         if let Some(key) = &self.signing_key {
-            let sig = Signature::new(&key);
+            let sig = Signature::new(key);
             match sig.hash() {
                 Ok(hashed) => {
                     sync_req = sync_req.header("authorization", format!("Bearer {}", hashed));
@@ -472,19 +471,14 @@ impl Handler {
         match sync_req.send().await {
             Ok(resp) => match resp.json::<InngestSyncSuccess>().await {
                 Ok(res) => {
-                    let modified = match res.modified.clone() {
-                        None => false,
-                        Some(v) => v,
-                    };
+                    let modified: bool = res.modified.unwrap_or_default();
 
-                    Ok(SyncResponse::OutOfBand(OutOfBandSyncResponse {
+                    Ok(SyncResponse::OutOfBand(Box::new(OutOfBandSyncResponse {
                         message: "Successfully synced.".to_string(),
                         modified,
-                    }))
+                    })))
                 }
-                Err(_) => {
-                    return Err("error parsing sync response".to_string());
-                }
+                Err(_) => Err("error parsing sync response".to_string()),
             },
             Err(err) => {
                 println!("ERROR: {:?}", err);
@@ -509,7 +503,7 @@ impl Handler {
 
         // Verify the signature if provided
         if let Some(sig) = sig.clone() {
-            _ = self.verify_signature(&sig, raw_body)?;
+            self.verify_signature(&sig, raw_body)?;
         }
 
         // find the specified function
@@ -530,7 +524,8 @@ struct RunRequestBody<T: 'static> {
     ctx: RunRequestCtx,
     event: Event<T>,
     events: Vec<Event<T>>,
-    use_api: bool,
+    #[serde(rename = "use_api")]
+    _use_api: bool,
     steps: HashMap<String, Option<Value>>,
     // version: i32,
 }
@@ -546,12 +541,6 @@ struct RunRequestCtx {
     // stack: RunRequestCtxStack,
 }
 
-#[derive(Deserialize, Debug)]
-struct RunRequestCtxStack {
-    // current: u32,
-    // stack: Vec<String>,
-}
-
 #[derive(Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Kind {
@@ -564,8 +553,8 @@ const PROBE_SCHEMA_VERSION: &str = "2024-05-24";
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum IntrospectResult {
-    Unauthenticated(IntrospectUnauthedResult),
-    Authenticated(IntrospectAuthedResult),
+    Unauthenticated(Box<IntrospectUnauthedResult>),
+    Authenticated(Box<IntrospectAuthedResult>),
 }
 
 #[derive(Serialize)]
@@ -606,8 +595,8 @@ pub struct IntrospectAuthedResult {
 
 #[derive(Serialize)]
 pub enum SyncResponse {
-    InBand(InBandSyncResponse),
-    OutOfBand(OutOfBandSyncResponse),
+    InBand(Box<InBandSyncResponse>),
+    OutOfBand(Box<OutOfBandSyncResponse>),
 }
 
 #[derive(Serialize)]
@@ -628,14 +617,10 @@ pub struct OutOfBandSyncResponse {
     modified: bool,
 }
 
-#[derive(Deserialize)]
-pub struct InngestSyncError {
-    error: String,
-}
-
 #[derive(Deserialize, Debug)]
 pub struct InngestSyncSuccess {
-    ok: bool,
+    #[serde(rename = "ok")]
+    _ok: bool,
     modified: Option<bool>,
 }
 

--- a/inngest/src/handler.rs
+++ b/inngest/src/handler.rs
@@ -71,6 +71,10 @@ impl DynamicServableFn {
     }
 }
 
+/// A type-erased function registration used by [`Handler::register_fns`].
+///
+/// Convert a [`ServableFn`] into a `RegisteredFn` with `.into()` when batching
+/// functions that use different event payload or error types.
 pub struct RegisteredFn(DynamicServableFn);
 
 impl RegisteredFn {
@@ -198,6 +202,12 @@ where
     }
 }
 
+/// An Inngest app handler that serves registered functions over HTTP.
+///
+/// A single handler can register functions with different event payload types.
+/// Use [`Handler::register_fn`] for one function at a time, or
+/// [`Handler::register_fns`] together with [`RegisteredFn`] to batch mixed
+/// function types.
 pub struct Handler {
     inngest: Inngest,
     signing_key: Option<String>,
@@ -221,6 +231,7 @@ pub struct SyncQueryParams {
 }
 
 impl Handler {
+    /// Creates a new handler for the given Inngest client.
     pub fn new(client: &Inngest) -> Self {
         let signing_key = Config::signing_key();
         let serve_origin = Config::serve_origin();
@@ -246,21 +257,28 @@ impl Handler {
         }
     }
 
+    /// Overrides the signing key used to verify inbound requests.
     pub fn signing_key(mut self, key: &str) -> Self {
         self.signing_key = Some(key.to_string());
         self
     }
 
+    /// Overrides the public origin used when syncing function URLs.
     pub fn serve_origin(mut self, origin: &str) -> Self {
         self.serve_origin = Some(origin.to_string());
         self
     }
 
+    /// Overrides the public path used when syncing function URLs.
     pub fn serve_path(mut self, path: &str) -> Self {
         self.serve_path = Some(path.to_string());
         self
     }
 
+    /// Registers a single function with the handler.
+    ///
+    /// This is the simplest option when adding one function at a time,
+    /// regardless of its event payload type.
     pub fn register_fn<T, E>(&mut self, func: ServableFn<T, E>)
     where
         T: InngestEvent + Send,
@@ -270,6 +288,17 @@ impl Handler {
         self.funcs.insert(func.slug(), func);
     }
 
+    /// Registers multiple functions with the handler.
+    ///
+    /// This accepts any iterator of [`RegisteredFn`], which allows batching
+    /// heterogeneous functions:
+    ///
+    /// ```ignore
+    /// handler.register_fns(vec![
+    ///     hello_fn(&client).into(),
+    ///     step_run_fn(&client).into(),
+    /// ]);
+    /// ```
     pub fn register_fns<I>(&mut self, funcs: I)
     where
         I: IntoIterator<Item = RegisteredFn>,

--- a/inngest/src/header.rs
+++ b/inngest/src/header.rs
@@ -34,11 +34,11 @@ impl Headers {
     }
 
     pub fn signature(&self) -> Option<String> {
-        self.0.get(INNGEST_SIGNATURE).map(|v| v.clone())
+        self.0.get(INNGEST_SIGNATURE).cloned()
     }
 
     pub fn host(&self) -> Option<String> {
-        self.0.get(HOST).map(|v| v.clone())
+        self.0.get(HOST).cloned()
     }
 }
 

--- a/inngest/src/serve/axum.rs
+++ b/inngest/src/serve/axum.rs
@@ -59,7 +59,7 @@ impl IntoResponse for SdkResponse {
         );
         headers.insert(
             header::INNGEST_FRAMEWORK,
-            HeaderValue::from_static(&FRAMEWORK),
+            HeaderValue::from_static(FRAMEWORK),
         );
         headers.insert(
             header::INNGEST_SDK,
@@ -86,7 +86,7 @@ impl IntoResponse for SyncResponse {
         );
         headers.insert(
             header::INNGEST_FRAMEWORK,
-            HeaderValue::from_static(&FRAMEWORK),
+            HeaderValue::from_static(FRAMEWORK),
         );
         headers.insert(
             header::INNGEST_SDK,
@@ -107,7 +107,7 @@ impl IntoResponse for IntrospectResult {
         );
         headers.insert(
             header::INNGEST_FRAMEWORK,
-            HeaderValue::from_static(&FRAMEWORK),
+            HeaderValue::from_static(FRAMEWORK),
         );
         headers.insert(
             header::INNGEST_SDK,

--- a/inngest/src/serve/axum.rs
+++ b/inngest/src/serve/axum.rs
@@ -12,41 +12,36 @@ use axum::{
     response::IntoResponse,
     Json,
 };
-use serde::Deserialize;
 use serde_json::json;
-use std::{fmt::Debug, sync::Arc};
+use std::sync::Arc;
 
 const FRAMEWORK: &str = "axum";
 
-pub async fn introspect<T, E>(
+pub async fn introspect(
     hmap: HeaderMap,
-    State(handler): State<Arc<Handler<T, E>>>,
+    State(handler): State<Arc<Handler>>,
     raw: String,
 ) -> Result<IntrospectResult, Error> {
     let headers = Headers::from(hmap);
     handler.introspect(&headers, FRAMEWORK, &raw).await
 }
 
-pub async fn register<T, E>(
+pub async fn register(
     hmap: HeaderMap,
     Query(query): Query<SyncQueryParams>,
-    State(handler): State<Arc<Handler<T, E>>>,
+    State(handler): State<Arc<Handler>>,
 ) -> Result<SyncResponse, String> {
     // convert the http headers into a generic hashmap
     let headers = Headers::from(hmap);
     handler.sync(&headers, &query, FRAMEWORK).await
 }
 
-pub async fn invoke<T, E>(
+pub async fn invoke(
     hmap: HeaderMap,
     Query(query): Query<RunQueryParams>,
-    State(handler): State<Arc<Handler<T, E>>>,
+    State(handler): State<Arc<Handler>>,
     raw: String,
-) -> Result<SdkResponse, Error>
-where
-    T: for<'de> Deserialize<'de> + Debug,
-    E: Into<Error>,
-{
+) -> Result<SdkResponse, Error> {
     let headers = Headers::from(hmap);
     match serde_json::from_str(&raw) {
         Ok(body) => handler.run(&headers, &query, &raw, &body).await,

--- a/inngest/src/signature.rs
+++ b/inngest/src/signature.rs
@@ -130,7 +130,7 @@ impl Signature {
     fn sign(&self, unix_ts: i64, signing_key: &str, body: &str) -> Result<String, Error> {
         let key = self.normalize_key(signing_key);
         let mut mac =
-            HmacSha256::new_from_slice(&key.as_bytes()).expect("HMAC can take key of any size");
+            HmacSha256::new_from_slice(key.as_bytes()).expect("HMAC can take key of any size");
         mac.update(format!("{}{}", body, unix_ts).as_bytes());
 
         let sum = mac.finalize();


### PR DESCRIPTION
## Summary

- refactors `Handler` to support registering and dispatching functions with different event payload and error types on the same handler
- updates the axum adapter to use the non-generic handler directly
- adds a handler test that proves mixed function types can coexist and execute correctly
- cleans up SDK clippy/test warnings across the touched Rust files
- updates `AGENTS.md` with the added agent instructions from this branch

## Why

The existing `Handler<T, E>` design forced a single handler to use one shared event/error type across all registered functions. That made heterogeneous function registration awkward and pushed callers toward umbrella enums. The handler refactor moves the typing boundary to registration time while keeping runtime dispatch by `fnId`.

#52 was closed, but the idea itself was still useful and provides more flexibility to the user, so capturing it here.

## Impact

Developers can now register functions with distinct event payload types on the same handler without changing the public axum serving pattern. The follow-up cleanup also leaves `make lint` and `make test` clean on this branch.

## Validation

- `cargo test -p inngest`
- `make lint`
- `make test`
