### PR TITLE
feat(step): add durable send_event support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Use standard conventional commit formatting such as `fix(promapi): handle empty 
 - `cargo check -p inngest` checks the crate without running tests
 - `cargo build -p inngest` builds the crate
 - `make dev` runs the `axum` example via `cargo run -p inngest --example axum`
-- `make inngest-dev` starts `inngest-cli` against `http://127.0.0.1:3000/api/inngest`
+- `make inngest-dev` starts `inngest` against `http://127.0.0.1:3000/api/inngest`
 
 ### Testing and Quality
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@
 dev:
 	cargo run -p inngest --example axum
 
+.PHONY: send-events
+send-events:
+	INNGEST_DEV=http://127.0.0.1:8288 cargo run -p inngest --example send_events
+
 .PHONY: test
 test:
 	cargo test
@@ -24,4 +28,4 @@ bump-version:
 
 .PHONY: inngest-dev
 inngest-dev:
-	inngest-cli dev -v -u http://127.0.0.1:3000/api/inngest
+	inngest dev -v -u http://127.0.0.1:3000/api/inngest

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If there are other frameworks you like to see, feel free to submit an issue, or 
 | `step.sleep`          | :white_check_mark: |
 | `step.wait_for_event` | :white_check_mark: |
 | `step.invoke`         | :white_check_mark: |
-| `step.send_event`     | :x:                |
+| `step.send_event`     | :white_check_mark: |
 | CancelOn              | :x:                |
 | Failure handler       | :x:                |
 | Retry controls        | :white_check_mark: |

--- a/flake.nix
+++ b/flake.nix
@@ -35,11 +35,68 @@
             "rustfmt"
           ];
         };
+
+        inngestRelease = {
+          version = "1.17.9";
+          x86_64-darwin = {
+            os = "darwin";
+            arch = "amd64";
+            hash = "sha256-9gbox1f9nABWf/KP7QIJDBqWk6VR+sosJuY7HmwHC9g=";
+          };
+          aarch64-darwin = {
+            os = "darwin";
+            arch = "arm64";
+            hash = "sha256-uk4e0/gOVEJFAr1Z2eVzCf8abR8IPHbYadQKmH5Y97w=";
+          };
+          x86_64-linux = {
+            os = "linux";
+            arch = "amd64";
+            hash = "sha256-Vh9uCOBNzdKfZngrhupWjntWMJvNBzYg/sGPGaBoOeI=";
+          };
+          aarch64-linux = {
+            os = "linux";
+            arch = "arm64";
+            hash = "sha256-iM6sackbdmz6Sbge2Xjx8kNlZ6uyUToE2NiojlSn82s=";
+          };
+        };
+
+        inngestAsset =
+          inngestRelease.${system}
+            or (throw "Unsupported system for inngest CLI release: ${system}");
+
+        inngestCli = pkgs.stdenvNoCC.mkDerivation {
+          pname = "inngest";
+          inherit (inngestRelease) version;
+
+          src = pkgs.fetchurl {
+            url =
+              "https://github.com/inngest/inngest/releases/download/v${inngestRelease.version}/"
+              + "inngest_${inngestRelease.version}_${inngestAsset.os}_${inngestAsset.arch}.tar.gz";
+            inherit (inngestAsset) hash;
+          };
+
+          nativeBuildInputs = with pkgs; [
+            gnutar
+            gzip
+          ];
+
+          sourceRoot = ".";
+          dontConfigure = true;
+          dontBuild = true;
+
+          installPhase = ''
+            runHook preInstall
+            install -Dm755 inngest $out/bin/inngest
+            install -Dm644 LICENSE.md $out/share/licenses/inngest/LICENSE.md
+            runHook postInstall
+          '';
+        };
       in
       {
         devShells.default = pkgs.mkShell {
           nativeBuildInputs = with pkgs; [
             rustToolchain
+            inngestCli
 
             # tools
             git-cliff

--- a/inngest/examples/send_events/main.rs
+++ b/inngest/examples/send_events/main.rs
@@ -17,12 +17,12 @@ async fn main() {
     let evts: Vec<&Event<Data>> = vec![&evt, &evt2];
 
     match client.send_event(&evt).await {
-        Ok(_) => println!("Success"),
-        Err(_) => println!("Error"),
+        Ok(response) => println!("Success: {:?}", response.ids),
+        Err(err) => println!("Error: {:?}", err),
     }
 
     match client.send_events(evts.as_slice()).await {
-        Ok(_) => println!("List success"),
-        Err(_) => println!("List error"),
+        Ok(response) => println!("List success: {:?}", response.ids),
+        Err(err) => println!("List error: {:?}", err),
     }
 }

--- a/inngest/src/client.rs
+++ b/inngest/src/client.rs
@@ -16,6 +16,16 @@ const API_ORIGIN_DEV: &str = "http://127.0.0.1:8288";
 pub(crate) const EVENT_API_ORIGIN: &str = "https://inn.gs";
 pub(crate) const API_ORIGIN: &str = "https://api.inngest.com";
 
+/// The response returned by the Inngest event ingestion API.
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
+pub struct SendEventResponse {
+    #[serde(default)]
+    pub ids: Vec<String>,
+    #[serde(default)]
+    pub status: u16,
+    pub error: Option<String>,
+}
+
 #[derive(Clone)]
 pub struct Inngest {
     id: String,
@@ -99,54 +109,75 @@ impl Inngest {
         let app_id = self.app_id();
         ServableFn {
             app_id,
+            client: self.clone(),
             opts,
             trigger,
             func: Box::new(move |input, step| func(input, step).boxed()),
         }
     }
 
-    // TODO: make the result return something properly
-    pub async fn send_event<T: InngestEvent>(&self, evt: &Event<T>) -> Result<(), DevError> {
-        self.http
-            .post(format!(
-                "{}/e/{}",
-                self.inngest_evt_api_origin(),
-                self.inngest_evt_api_key()
-            ))
-            .json(&evt)
-            .send()
-            .await
-            .map(|_| ())
-            .map_err(|err| DevError::Basic(format!("{}", err)))
+    /// Sends a single event to the configured Inngest event API.
+    pub async fn send_event<T: InngestEvent>(
+        &self,
+        evt: &Event<T>,
+    ) -> Result<SendEventResponse, DevError> {
+        self.send_payload(evt).await
     }
 
-    // TODO: make the result return something properly
-    pub async fn send_events<T: InngestEvent>(&self, evts: &[&Event<T>]) -> Result<(), DevError> {
-        self.http
-            .post(format!(
-                "{}/e/{}",
-                self.inngest_evt_api_origin(),
-                self.inngest_evt_api_key()
-            ))
-            .json(&evts)
-            .send()
-            .await
-            .map(|_| ())
-            .map_err(|err| DevError::Basic(format!("{}", err)))
+    /// Sends multiple events to the configured Inngest event API.
+    pub async fn send_events<T: InngestEvent>(
+        &self,
+        evts: &[&Event<T>],
+    ) -> Result<SendEventResponse, DevError> {
+        self.send_payload(evts).await
     }
 
-    pub(crate) fn inngest_api_origin(&self, kind: Kind) -> String {
-        if let Some(dev) = self.dev.clone() {
-            return dev;
+    pub(crate) async fn send_owned_events_with_ids<T: InngestEvent>(
+        &self,
+        evts: &[Event<T>],
+    ) -> Result<Vec<String>, DevError> {
+        self.send_payload(evts).await.map(|response| response.ids)
+    }
+
+    async fn send_payload<T: serde::Serialize + ?Sized>(
+        &self,
+        payload: &T,
+    ) -> Result<SendEventResponse, DevError> {
+        let event_url = self.event_api_url();
+        let response = self
+            .http
+            .post(event_url)
+            .json(payload)
+            .send()
+            .await
+            .map_err(|err| DevError::Basic(format!("{}", err)))?;
+
+        let http_status = response.status();
+        let body: SendEventResponse = response.json().await.map_err(|err| {
+            DevError::Basic(format!("error decoding event send response: {}", err))
+        })?;
+
+        if !http_status.is_success() || body.status != 200 || body.error.is_some() {
+            let message = body.error.unwrap_or_else(|| {
+                format!(
+                    "unexpected event send response (http {}, body {})",
+                    http_status.as_u16(),
+                    body.status
+                )
+            });
+            return Err(DevError::Basic(message));
         }
 
-        if let Some(endpoint) = self.api_origin.clone() {
-            return endpoint;
-        }
+        Ok(body)
+    }
 
-        match kind {
-            Kind::Dev => API_ORIGIN_DEV.to_string(),
-            Kind::Cloud => API_ORIGIN.to_string(),
+    fn event_api_url(&self) -> String {
+        let origin = self.inngest_evt_api_origin();
+        let event_key = self.inngest_evt_api_key();
+
+        match Url::parse(&origin).and_then(|url| url.join(&format!("e/{}", event_key))) {
+            Ok(url) => url.to_string(),
+            Err(_) => format!("{}/e/{}", origin.trim_end_matches('/'), event_key),
         }
     }
 
@@ -171,5 +202,97 @@ impl Inngest {
             Some(key) => key,
             None => "test".to_string(),
         }
+    }
+
+    pub(crate) fn inngest_api_origin(&self, kind: Kind) -> String {
+        if let Some(dev) = self.dev.clone() {
+            return dev;
+        }
+
+        if let Some(endpoint) = self.api_origin.clone() {
+            return endpoint;
+        }
+
+        match kind {
+            Kind::Dev => API_ORIGIN_DEV.to_string(),
+            Kind::Cloud => API_ORIGIN.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{routing::post, Json, Router};
+    use serde::{Deserialize, Serialize};
+    use serde_json::{json, Value};
+    use std::net::TcpListener;
+
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    struct TestEventData {
+        value: String,
+    }
+
+    #[tokio::test]
+    async fn send_event_returns_send_event_response() {
+        async fn ingest(Json(_body): Json<Value>) -> Json<Value> {
+            Json(json!({
+                "ids": ["evt-1"],
+                "status": 200
+            }))
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+        let addr = listener.local_addr().expect("listener addr should exist");
+        let app = Router::new().route("/e/:event_key", post(ingest));
+
+        tokio::spawn(async move {
+            axum::Server::from_tcp(listener)
+                .expect("server should bind")
+                .serve(app.into_make_service())
+                .await
+                .expect("server should serve");
+        });
+
+        let client = Inngest::new("test-app")
+            .event_api_origin(&format!("http://{}", addr))
+            .event_key("test-key");
+        let response = client
+            .send_event(&Event::new(
+                "test/send",
+                TestEventData {
+                    value: "hello".to_string(),
+                },
+            ))
+            .await
+            .expect("send_event should return the parsed response");
+
+        assert_eq!(
+            response,
+            SendEventResponse {
+                ids: vec!["evt-1".to_string()],
+                status: 200,
+                error: None,
+            }
+        );
+    }
+
+    #[test]
+    fn event_api_url_normalizes_trailing_slash() {
+        let with_slash = Inngest::new("test-app")
+            .event_api_origin("http://127.0.0.1:8288/")
+            .event_key("test-key");
+        let without_slash = Inngest::new("test-app")
+            .event_api_origin("http://127.0.0.1:8288")
+            .event_key("test-key");
+
+        assert_eq!(
+            with_slash.event_api_url(),
+            "http://127.0.0.1:8288/e/test-key"
+        );
+        assert_eq!(
+            without_slash.event_api_url(),
+            "http://127.0.0.1:8288/e/test-key"
+        );
     }
 }

--- a/inngest/src/function.rs
+++ b/inngest/src/function.rs
@@ -1,4 +1,5 @@
 use crate::{
+    client::Inngest,
     event::{Event, InngestEvent},
     step_tool::Step as StepTool,
 };
@@ -61,6 +62,7 @@ type Func<T, E> =
 
 pub struct ServableFn<T: 'static, E> {
     pub(crate) app_id: String,
+    pub(crate) client: Inngest,
     pub opts: FunctionOpts,
     pub trigger: Trigger,
     pub func: Box<Func<T, E>>,

--- a/inngest/src/handler.rs
+++ b/inngest/src/handler.rs
@@ -91,6 +91,7 @@ where
     fn from(func: ServableFn<T, E>) -> Self {
         let ServableFn {
             app_id,
+            client,
             opts,
             trigger,
             func,
@@ -103,6 +104,7 @@ where
             trigger,
             func: Box::new(move |fn_id, body| {
                 let step_func = Arc::clone(&func);
+                let client = client.clone();
 
                 async move {
                     let data = match serde_json::from_value::<RunRequestBody<T>>(body.clone()) {
@@ -129,7 +131,7 @@ where
                         },
                     };
 
-                    let step_tool = StepTool::new(&data.steps);
+                    let step_tool = StepTool::new(client.clone(), &data.steps);
 
                     match std::panic::catch_unwind(AssertUnwindSafe(|| {
                         (step_func.as_ref())(input, step_tool.clone())

--- a/inngest/src/step_tool.rs
+++ b/inngest/src/step_tool.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     error::Error as StdError,
+    fmt::{Display, Formatter},
     future::Future,
     time::{self, Duration, SystemTime},
 };
@@ -13,8 +14,9 @@ use state::State;
 
 use crate::{
     basic_error,
+    client::Inngest,
     event::{Event, InngestEvent},
-    result::{Error, FlowControlError, StepError},
+    result::{DevError, Error, FlowControlError, StepError},
     utils::duration,
 };
 
@@ -115,6 +117,7 @@ mod state {
 
 #[derive(Clone)]
 pub struct Step {
+    client: Inngest,
     state: state::State,
 }
 
@@ -133,8 +136,10 @@ impl<E> UserProvidedError<'_> for E where
 }
 
 impl Step {
-    pub fn new(state: &HashMap<String, Option<Value>>) -> Self {
+    /// Creates a step helper for the current function execution.
+    pub(crate) fn new(client: Inngest, state: &HashMap<String, Option<Value>>) -> Self {
         Step {
+            client,
             state: State::new(state),
         }
     }
@@ -387,8 +392,30 @@ impl Step {
         }
     }
 
-    // TODO: send_event
-    // TODO: send_events
+    /// Sends one event durably and returns the emitted event IDs.
+    pub async fn send_event<T: InngestEvent>(
+        &self,
+        id: &str,
+        evt: Event<T>,
+    ) -> Result<Vec<String>, Error> {
+        self.send_events(id, vec![evt]).await
+    }
+
+    /// Sends multiple events durably and returns the emitted event IDs.
+    pub async fn send_events<T: InngestEvent>(
+        &self,
+        id: &str,
+        evts: Vec<Event<T>>,
+    ) -> Result<Vec<String>, Error> {
+        let client = self.client.clone();
+        self.run(id, || async move {
+            client
+                .send_owned_events_with_ids(evts.as_slice())
+                .await
+                .map_err(StepSendEventError::from)
+        })
+        .await
+    }
 }
 
 pub struct WaitForEventOpts {
@@ -401,6 +428,37 @@ pub struct InvokeFunctionOpts {
     pub function_id: String,
     pub data: Value,
     pub timeout: Option<Duration>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct StepSendEventError {
+    message: String,
+}
+
+impl Display for StepSendEventError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl StdError for StepSendEventError {}
+
+impl From<DevError> for StepSendEventError {
+    fn from(err: DevError) -> Self {
+        let message = match err {
+            DevError::Basic(message) => message,
+            DevError::RetryAt(err) => err.to_string(),
+            DevError::NoRetry(err) => err.to_string(),
+        };
+
+        Self { message }
+    }
+}
+
+impl From<StepSendEventError> for Error {
+    fn from(err: StepSendEventError) -> Self {
+        Error::Dev(DevError::Basic(err.message))
+    }
 }
 
 struct Op {
@@ -428,6 +486,27 @@ impl Op {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::client::Inngest;
+    use axum::{extract::State, response::IntoResponse, routing::post, Json, Router};
+    use serde_json::json;
+    use std::{
+        net::TcpListener,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc, Mutex,
+        },
+    };
+
+    #[derive(Clone, Default)]
+    struct EventApiState {
+        requests: Arc<AtomicUsize>,
+        bodies: Arc<Mutex<Vec<Value>>>,
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    struct TestEventData {
+        value: String,
+    }
 
     #[test]
     fn test_op_hash() {
@@ -447,5 +526,144 @@ mod tests {
         };
 
         assert_eq!(op.hash(), "20A9BB9477C4AC565CF084D1614C58BBF0A523FF");
+    }
+
+    #[tokio::test]
+    async fn send_event_emits_step_run_and_reuses_memoized_result() {
+        let server = spawn_event_api().await;
+        let client = Inngest::new("test-app")
+            .event_api_origin(&server.url)
+            .event_key("test-key");
+        let step = Step::new(client.clone(), &HashMap::new());
+
+        let first = step
+            .send_event(
+                "send-test",
+                Event::new(
+                    "test/send",
+                    TestEventData {
+                        value: "hello".to_string(),
+                    },
+                ),
+            )
+            .await;
+
+        match first {
+            Err(Error::Interrupt(mut flow)) => flow.acknowledge(),
+            other => panic!("expected step interruption, got {other:?}"),
+        }
+
+        assert_eq!(server.state.requests.load(Ordering::SeqCst), 1);
+        assert_eq!(step.genop().len(), 1);
+        assert_eq!(step.genop()[0].data, Some(json!(["evt-1"])));
+
+        let stored = HashMap::from([(
+            step.genop()[0].id.clone(),
+            Some(json!({ "data": ["evt-1"] })),
+        )]);
+        let memoized_step = Step::new(client, &stored);
+        let second = memoized_step
+            .send_event(
+                "send-test",
+                Event::new(
+                    "test/send",
+                    TestEventData {
+                        value: "ignored".to_string(),
+                    },
+                ),
+            )
+            .await
+            .expect("memoized step should return stored IDs");
+
+        assert_eq!(second, vec!["evt-1".to_string()]);
+        assert_eq!(server.state.requests.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn send_events_posts_an_array_payload() {
+        let server = spawn_event_api().await;
+        let client = Inngest::new("test-app")
+            .event_api_origin(&server.url)
+            .event_key("test-key");
+        let step = Step::new(client, &HashMap::new());
+
+        let result = step
+            .send_events(
+                "send-many",
+                vec![
+                    Event::new(
+                        "test/send.first",
+                        TestEventData {
+                            value: "first".to_string(),
+                        },
+                    ),
+                    Event::new(
+                        "test/send.second",
+                        TestEventData {
+                            value: "second".to_string(),
+                        },
+                    ),
+                ],
+            )
+            .await;
+
+        match result {
+            Err(Error::Interrupt(mut flow)) => flow.acknowledge(),
+            other => panic!("expected step interruption, got {other:?}"),
+        }
+
+        assert_eq!(step.genop()[0].data, Some(json!(["evt-1", "evt-2"])));
+
+        let bodies = server.state.bodies.lock().unwrap();
+        assert_eq!(bodies.len(), 1);
+        assert!(bodies[0].is_array());
+        assert_eq!(bodies[0].as_array().unwrap().len(), 2);
+    }
+
+    struct TestServer {
+        state: EventApiState,
+        url: String,
+    }
+
+    async fn spawn_event_api() -> TestServer {
+        async fn ingest(
+            State(state): State<EventApiState>,
+            Json(body): Json<Value>,
+        ) -> impl IntoResponse {
+            state.requests.fetch_add(1, Ordering::SeqCst);
+            state.bodies.lock().unwrap().push(body.clone());
+
+            let ids = match body {
+                Value::Array(ref events) => (1..=events.len())
+                    .map(|idx| format!("evt-{}", idx))
+                    .collect::<Vec<_>>(),
+                _ => vec!["evt-1".to_string()],
+            };
+
+            Json(json!({
+                "ids": ids,
+                "status": 200
+            }))
+        }
+
+        let state = EventApiState::default();
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+        let addr = listener.local_addr().expect("listener addr should exist");
+        let app = Router::new()
+            .route("/e/:event_key", post(ingest))
+            .with_state(state.clone());
+
+        tokio::spawn(async move {
+            axum::Server::from_tcp(listener)
+                .expect("server should bind")
+                .serve(app.into_make_service())
+                .await
+                .expect("server should serve");
+        });
+
+        TestServer {
+            state,
+            url: format!("http://{}", addr),
+        }
     }
 }


### PR DESCRIPTION
Resolves #45.

## What changed

This PR adds durable `step.send_event` support to the Rust SDK and handles both single-event and multi-event sends.

It implements send-event steps as wrapped run steps so the result is retriable and memoized, and returns the sent event IDs from the step result.

It also updates the public client send APIs to return the parsed event API response shape instead of discarding it, fixes event API URL construction when the configured origin has a trailing slash, and adds a `make send-events` helper for the example.

## Why

Issue #45 asked for event sending within a step, including support for both a single event and a vector of events. The SDK spec allows this to be implemented as a wrapped run step as long as the send is durable and memoized.

## Impact

Developers can now emit events durably from within functions using `step.send_event` / `step.send_events` and receive the resulting event IDs.

## Validation

- `cargo test -p inngest`
- `cargo clippy -p inngest --all-features -- -D warnings`

## Notes

- `Step` now requires the real `Inngest` client during execution instead of constructing a synthetic fallback client.
- The send-events example target still depends on the local environment being able to initialize `reqwest` successfully on macOS.
