### PR TITLE
test(e2e): expand dev-server integration coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,10 +102,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: DeterminateSystems/nix-installer-action@v22
+      - name: Initialize Nix dev shell
+        run: nix develop -c true
       - name: Run e2e tests
-        run: |
-          nix develop -c cargo test -p inngest \
-            --test send_event_e2e \
-            --test wait_for_event_e2e \
-            --test invoke_e2e \
-            -- --test-threads=1
+        run: nix develop -c make test-e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,10 @@ jobs:
     # needs: [build]
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
       - name: Cache
         uses: actions/cache@v3
         with:
@@ -94,5 +98,14 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - name: Install Inngest CLI shim
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          cat > "$HOME/.local/bin/inngest" <<'EOF'
+          #!/usr/bin/env bash
+          exec npx --yes inngest-cli@latest "$@"
+          EOF
+          chmod +x "$HOME/.local/bin/inngest"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Test
         run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,6 @@ jobs:
     # needs: [build]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
       - name: Cache
         uses: actions/cache@v3
         with:
@@ -98,14 +94,18 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - name: Install Inngest CLI shim
-        run: |
-          mkdir -p "$HOME/.local/bin"
-          cat > "$HOME/.local/bin/inngest" <<'EOF'
-          #!/usr/bin/env bash
-          exec npx --yes inngest-cli@latest "$@"
-          EOF
-          chmod +x "$HOME/.local/bin/inngest"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Test
-        run: cargo test
+        run: cargo test -p inngest --lib
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - name: Run e2e tests
+        run: |
+          nix develop -c cargo test -p inngest \
+            --test send_event_e2e \
+            --test wait_for_event_e2e \
+            --test invoke_e2e \
+            -- --test-threads=1

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ send-events:
 test:
 	cargo test
 
+.PHONY: test-e2e
+test-e2e:
+	./scripts/run-e2e-tests.sh
+
 .PHONY: lint
 lint:
 	cargo clippy

--- a/inngest/src/handler.rs
+++ b/inngest/src/handler.rs
@@ -497,7 +497,7 @@ impl Handler {
         let mut sync_req = reqwest::Client::new()
             .post(format!(
                 "{}/fn/register",
-                self.inngest.inngest_api_origin(kind)
+                self.inngest.inngest_api_origin(kind).trim_end_matches('/')
             ))
             .json(&req);
 
@@ -518,17 +518,38 @@ impl Handler {
         }
 
         match sync_req.send().await {
-            Ok(resp) => match resp.json::<InngestSyncSuccess>().await {
-                Ok(res) => {
+            Ok(resp) => {
+                let status = resp.status();
+                let body = match resp.text().await {
+                    Ok(body) => body,
+                    Err(err) => {
+                        return Err(format!("error reading sync response: {}", err));
+                    }
+                };
+
+                if !status.is_success() {
+                    return Err(format!(
+                        "error registering: status {} body {}",
+                        status.as_u16(),
+                        body
+                    ));
+                }
+
+                match serde_json::from_str::<InngestSyncSuccess>(&body) {
+                    Ok(res) => {
                     let modified: bool = res.modified.unwrap_or_default();
 
                     Ok(SyncResponse::OutOfBand(Box::new(OutOfBandSyncResponse {
                         message: "Successfully synced.".to_string(),
                         modified,
                     })))
+                    }
+                    Err(err) => Err(format!(
+                        "error parsing sync response: {} body {}",
+                        err, body
+                    )),
                 }
-                Err(_) => Err("error parsing sync response".to_string()),
-            },
+            }
             Err(err) => {
                 println!("ERROR: {:?}", err);
 

--- a/inngest/src/handler.rs
+++ b/inngest/src/handler.rs
@@ -537,12 +537,12 @@ impl Handler {
 
                 match serde_json::from_str::<InngestSyncSuccess>(&body) {
                     Ok(res) => {
-                    let modified: bool = res.modified.unwrap_or_default();
+                        let modified: bool = res.modified.unwrap_or_default();
 
-                    Ok(SyncResponse::OutOfBand(Box::new(OutOfBandSyncResponse {
-                        message: "Successfully synced.".to_string(),
-                        modified,
-                    })))
+                        Ok(SyncResponse::OutOfBand(Box::new(OutOfBandSyncResponse {
+                            message: "Successfully synced.".to_string(),
+                            modified,
+                        })))
                     }
                     Err(err) => Err(format!(
                         "error parsing sync response: {} body {}",

--- a/inngest/src/step_tool.rs
+++ b/inngest/src/step_tool.rs
@@ -350,10 +350,7 @@ impl Step {
         match self.get_hashed(&hashed) {
             Some(resp) => match resp {
                 None => Err(Error::NoInvokeFunctionResponseError),
-                Some(v) => match serde_json::from_value::<T>(v.clone()) {
-                    Ok(res) => Ok(res),
-                    Err(err) => Err(basic_error!("error deserializing invoke result: {}", err)),
-                },
+                Some(v) => parse_invoke_response(v),
             },
 
             None => {
@@ -416,6 +413,32 @@ impl Step {
         })
         .await
     }
+}
+
+fn parse_invoke_response<T: for<'de> Deserialize<'de>>(value: Value) -> Result<T, Error> {
+    #[derive(Deserialize)]
+    struct InvokeErrorBody {
+        message: String,
+    }
+
+    #[derive(Deserialize)]
+    struct InvokeResponse<T> {
+        data: Option<T>,
+        error: Option<InvokeErrorBody>,
+    }
+
+    let response = serde_json::from_value::<InvokeResponse<T>>(value)
+        .map_err(|err| basic_error!("error deserializing invoke result: {}", err))?;
+
+    if let Some(data) = response.data {
+        return Ok(data);
+    }
+
+    if let Some(err) = response.error {
+        return Err(basic_error!("{}", err.message));
+    }
+
+    Err(basic_error!("error parsing invoke result: unknown shape"))
 }
 
 pub struct WaitForEventOpts {
@@ -618,6 +641,32 @@ mod tests {
         assert_eq!(bodies.len(), 1);
         assert!(bodies[0].is_array());
         assert_eq!(bodies[0].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn invoke_response_returns_data_field() {
+        let response = parse_invoke_response::<String>(json!({
+            "data": "hello"
+        }))
+        .expect("invoke response should deserialize data");
+
+        assert_eq!(response, "hello");
+    }
+
+    #[test]
+    fn invoke_response_returns_error_field() {
+        let response = parse_invoke_response::<String>(json!({
+            "error": {
+                "message": "invoke failed"
+            }
+        }));
+
+        match response {
+            Err(Error::Dev(DevError::Basic(message))) => {
+                assert_eq!(message, "invoke failed");
+            }
+            other => panic!("expected invoke error, got {other:?}"),
+        }
     }
 
     struct TestServer {

--- a/inngest/tests/e2e_support/mod.rs
+++ b/inngest/tests/e2e_support/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use axum::Router;
 use inngest::{client::Inngest, handler::Handler, serve};
 use serde::Deserialize;

--- a/inngest/tests/e2e_support/mod.rs
+++ b/inngest/tests/e2e_support/mod.rs
@@ -1,0 +1,294 @@
+use axum::Router;
+use inngest::{client::Inngest, handler::Handler, serve};
+use serde::Deserialize;
+use serde_json::Value;
+use std::{
+    fs, io,
+    net::TcpListener,
+    path::PathBuf,
+    process::{Child, Command, Stdio},
+    sync::{Arc, Mutex},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+pub const DEV_SERVER_ORIGIN: &str = "http://127.0.0.1:8288";
+
+#[derive(Debug, Deserialize)]
+struct ApiEnvelope<T> {
+    data: T,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct EventRunRecord {
+    pub run_id: String,
+    pub status: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RunRecord {
+    pub status: String,
+    #[serde(default)]
+    pub output: Value,
+}
+
+pub struct AppServer {
+    base_url: String,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl AppServer {
+    pub async fn sync(&self) {
+        let response = reqwest::Client::new()
+            .put(format!("{}/api/inngest", self.base_url))
+            .send()
+            .await
+            .expect("sync request should complete");
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .expect("sync response body should be readable");
+
+        assert!(status.is_success(), "sync request failed with status {}", status);
+
+        serde_json::from_str::<Value>(&body).unwrap_or_else(|_| {
+            panic!("sync request returned a non-JSON body: {body}");
+        });
+    }
+}
+
+impl Drop for AppServer {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+pub struct DevServer {
+    child: Child,
+}
+
+impl DevServer {
+    pub async fn start() -> Self {
+        let child = Command::new("inngest")
+            .args(["dev", "--no-discovery", "--no-poll", "--port", "8288"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("inngest dev server should start");
+
+        wait_for_http_ok(DEV_SERVER_ORIGIN, Duration::from_secs(20)).await;
+
+        Self { child }
+    }
+}
+
+impl Drop for DevServer {
+    fn drop(&mut self) {
+        if let Ok(None) = self.child.try_wait() {
+            let _ = self.child.kill();
+        }
+
+        let _ = self.child.wait();
+    }
+}
+
+pub struct DevServerLock {
+    path: PathBuf,
+}
+
+impl DevServerLock {
+    pub fn acquire() -> Self {
+        let path = std::env::temp_dir().join("inngest-rs-dev-server-e2e.lock");
+        let deadline = Instant::now() + Duration::from_secs(30);
+
+        loop {
+            match fs::create_dir(&path) {
+                Ok(()) => return Self { path },
+                Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "timed out waiting for dev server lock"
+                    );
+                    std::thread::sleep(Duration::from_millis(100));
+                }
+                Err(err) => panic!("failed to create dev server lock: {err}"),
+            }
+        }
+    }
+}
+
+impl Drop for DevServerLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir(&self.path);
+    }
+}
+
+pub async fn spawn_app(
+    client: Inngest,
+    funcs: Vec<inngest::handler::RegisteredFn>,
+) -> AppServer {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("listener should have a local address");
+    let base_url = format!("http://127.0.0.1:{}", addr.port());
+
+    let mut handler = Handler::new(&client).serve_origin(&base_url);
+    handler.register_fns(funcs);
+
+    let app = Router::new()
+        .route(
+            "/api/inngest",
+            axum::routing::get(serve::axum::introspect)
+                .put(serve::axum::register)
+                .post(serve::axum::invoke),
+        )
+        .with_state(Arc::new(handler));
+
+    let task = tokio::spawn(async move {
+        axum::Server::from_tcp(listener)
+            .expect("server should bind")
+            .serve(app.into_make_service())
+            .await
+            .expect("server should serve");
+    });
+
+    AppServer { base_url, task }
+}
+
+pub async fn wait_for_run_status(
+    run_id: &str,
+    expected_status: &str,
+    timeout: Duration,
+) -> RunRecord {
+    let deadline = Instant::now() + timeout;
+    let mut last_status = None::<String>;
+
+    loop {
+        if let Some(run) = fetch_run(run_id).await {
+            if run.status == expected_status {
+                return run;
+            }
+            last_status = Some(run.status);
+        }
+
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for run {run_id} to reach status {expected_status}; last status was {:?}",
+            last_status
+        );
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+pub async fn wait_for_event_runs(event_id: &str, timeout: Duration) -> Vec<EventRunRecord> {
+    let deadline = Instant::now() + timeout;
+
+    loop {
+        let runs = fetch_event_runs(event_id).await;
+        if !runs.is_empty() {
+            return runs;
+        }
+
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for event {event_id} to produce runs"
+        );
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+pub async fn wait_for_state<T: Clone>(state: &Arc<Mutex<Option<T>>>, timeout: Duration) -> T {
+    let deadline = Instant::now() + timeout;
+
+    loop {
+        if let Some(value) = state.lock().unwrap().clone() {
+            return value;
+        }
+
+        assert!(Instant::now() < deadline, "timed out waiting for state");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+pub fn unique_name(prefix: &str) -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after unix epoch")
+        .as_nanos();
+
+    format!("{prefix}-{now}")
+}
+
+async fn wait_for_http_ok(origin: &str, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    let client = reqwest::Client::new();
+
+    loop {
+        if let Ok(response) = client.get(origin).send().await {
+            if response.status().is_success() {
+                return;
+            }
+        }
+
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {origin} to become healthy"
+        );
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn fetch_run(run_id: &str) -> Option<RunRecord> {
+    let response = reqwest::Client::new()
+        .get(format!("{DEV_SERVER_ORIGIN}/v1/runs/{run_id}"))
+        .send()
+        .await
+        .expect("run lookup should complete");
+
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return None;
+    }
+
+    assert!(
+        response.status().is_success(),
+        "run lookup failed with status {}",
+        response.status()
+    );
+
+    let envelope = response
+        .json::<ApiEnvelope<RunRecord>>()
+        .await
+        .expect("run lookup should decode");
+
+    Some(envelope.data)
+}
+
+async fn fetch_event_runs(event_id: &str) -> Vec<EventRunRecord> {
+    let response = reqwest::Client::new()
+        .get(format!("{DEV_SERVER_ORIGIN}/v1/events/{event_id}/runs"))
+        .send()
+        .await
+        .expect("event run lookup should complete");
+
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return Vec::new();
+    }
+
+    assert!(
+        response.status().is_success(),
+        "event run lookup failed with status {}",
+        response.status()
+    );
+
+    let envelope = response
+        .json::<ApiEnvelope<Vec<EventRunRecord>>>()
+        .await
+        .expect("event run lookup should decode");
+
+    envelope.data
+}

--- a/inngest/tests/e2e_support/mod.rs
+++ b/inngest/tests/e2e_support/mod.rs
@@ -51,7 +51,11 @@ impl AppServer {
             .await
             .expect("sync response body should be readable");
 
-        assert!(status.is_success(), "sync request failed with status {}", status);
+        assert!(
+            status.is_success(),
+            "sync request failed with status {}",
+            status
+        );
 
         serde_json::from_str::<Value>(&body).unwrap_or_else(|_| {
             panic!("sync request returned a non-JSON body: {body}");
@@ -126,10 +130,7 @@ impl Drop for DevServerLock {
     }
 }
 
-pub async fn spawn_app(
-    client: Inngest,
-    funcs: Vec<inngest::handler::RegisteredFn>,
-) -> AppServer {
+pub async fn spawn_app(client: Inngest, funcs: Vec<inngest::handler::RegisteredFn>) -> AppServer {
     let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
     let addr = listener
         .local_addr()

--- a/inngest/tests/e2e_support/mod.rs
+++ b/inngest/tests/e2e_support/mod.rs
@@ -40,6 +40,7 @@ pub struct AppServer {
 
 impl AppServer {
     pub async fn sync(&self) {
+        // Sync the SDK app with the dev server after the local axum app is listening.
         let response = reqwest::Client::new()
             .put(format!("{}/api/inngest", self.base_url))
             .send()
@@ -75,6 +76,7 @@ pub struct DevServer {
 
 impl DevServer {
     pub async fn start() -> Self {
+        // Each e2e test owns the single shared dev server while holding the lock below.
         let child = Command::new("inngest")
             .args(["dev", "--no-discovery", "--no-poll", "--port", "8288"])
             .stdin(Stdio::null())
@@ -105,6 +107,7 @@ pub struct DevServerLock {
 
 impl DevServerLock {
     pub fn acquire() -> Self {
+        // The dev server uses fixed ports, so keep the e2e suite serialized.
         let path = std::env::temp_dir().join("inngest-rs-dev-server-e2e.lock");
         let deadline = Instant::now() + Duration::from_secs(30);
 
@@ -131,6 +134,7 @@ impl Drop for DevServerLock {
 }
 
 pub async fn spawn_app(client: Inngest, funcs: Vec<inngest::handler::RegisteredFn>) -> AppServer {
+    // Give each test app its own ephemeral HTTP server and sync only the functions it needs.
     let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
     let addr = listener
         .local_addr()
@@ -165,6 +169,7 @@ pub async fn wait_for_run_status(
     expected_status: &str,
     timeout: Duration,
 ) -> RunRecord {
+    // The dev server updates runs asynchronously, so poll until the desired state appears.
     let deadline = Instant::now() + timeout;
     let mut last_status = None::<String>;
 
@@ -187,6 +192,7 @@ pub async fn wait_for_run_status(
 }
 
 pub async fn wait_for_event_runs(event_id: &str, timeout: Duration) -> Vec<EventRunRecord> {
+    // Child runs may not exist immediately after the parent emits the durable event.
     let deadline = Instant::now() + timeout;
 
     loop {
@@ -205,6 +211,7 @@ pub async fn wait_for_event_runs(event_id: &str, timeout: Duration) -> Vec<Event
 }
 
 pub async fn wait_for_state<T: Clone>(state: &Arc<Mutex<Option<T>>>, timeout: Duration) -> T {
+    // Test functions communicate back to the harness through shared in-memory state.
     let deadline = Instant::now() + timeout;
 
     loop {
@@ -218,6 +225,7 @@ pub async fn wait_for_state<T: Clone>(state: &Arc<Mutex<Option<T>>>, timeout: Du
 }
 
 pub fn unique_name(prefix: &str) -> String {
+    // Reusing names across tests makes dev-server sync confusing, so keep them unique.
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("clock should be after unix epoch")
@@ -227,6 +235,7 @@ pub fn unique_name(prefix: &str) -> String {
 }
 
 async fn wait_for_http_ok(origin: &str, timeout: Duration) {
+    // The CLI can take a moment to boot before its HTTP endpoints are ready.
     let deadline = Instant::now() + timeout;
     let client = reqwest::Client::new();
 
@@ -247,6 +256,7 @@ async fn wait_for_http_ok(origin: &str, timeout: Duration) {
 }
 
 async fn fetch_run(run_id: &str) -> Option<RunRecord> {
+    // Missing runs are normal while the event is still being ingested.
     let response = reqwest::Client::new()
         .get(format!("{DEV_SERVER_ORIGIN}/v1/runs/{run_id}"))
         .send()
@@ -272,6 +282,7 @@ async fn fetch_run(run_id: &str) -> Option<RunRecord> {
 }
 
 async fn fetch_event_runs(event_id: &str) -> Vec<EventRunRecord> {
+    // Child event runs appear only after the durable event has been dispatched.
     let response = reqwest::Client::new()
         .get(format!("{DEV_SERVER_ORIGIN}/v1/events/{event_id}/runs"))
         .send()

--- a/inngest/tests/invoke_e2e.rs
+++ b/inngest/tests/invoke_e2e.rs
@@ -1,0 +1,90 @@
+mod e2e_support;
+
+use e2e_support::{spawn_app, wait_for_run_status, wait_for_state, DevServer, DevServerLock};
+use inngest::{
+    client::Inngest,
+    event::Event,
+    function::{FunctionOpts, Input, ServableFn, Trigger},
+    result::Error,
+    step_tool::{InvokeFunctionOpts, Step as StepTool},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+#[derive(Debug, Deserialize, Serialize)]
+struct EmptyEventData {}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct InvokeEventData {
+    message: String,
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn step_invoke_returns_child_output() {
+    let _lock = DevServerLock::acquire();
+    let _dev_server = DevServer::start().await;
+
+    let app_name = e2e_support::unique_name("invoke-e2e-app");
+    let parent_event_name = e2e_support::unique_name("test.invoke.parent");
+
+    let client = Inngest::new(&app_name).dev(e2e_support::DEV_SERVER_ORIGIN);
+    let parent_run_id = Arc::new(Mutex::new(None::<String>));
+    let invoke_result = Arc::new(Mutex::new(None::<String>));
+
+    let child_fn: ServableFn<InvokeEventData, Error> = client.create_function(
+        FunctionOpts::new("invoke-child-fn").name("Invoke Child Fn"),
+        Trigger::event("never"),
+        |input: Input<InvokeEventData>, _step: StepTool| async move {
+            Ok(json!(input.event.data.message))
+        },
+    );
+    let child_fn_id = child_fn.slug();
+
+    let parent_run_state = Arc::clone(&parent_run_id);
+    let invoke_result_state = Arc::clone(&invoke_result);
+    let parent_fn: ServableFn<EmptyEventData, Error> = client.create_function(
+        FunctionOpts::new("invoke-parent-fn").name("Invoke Parent Fn"),
+        Trigger::event(&parent_event_name),
+        move |input: Input<EmptyEventData>, step: StepTool| {
+            let parent_run_state = Arc::clone(&parent_run_state);
+            let invoke_result_state = Arc::clone(&invoke_result_state);
+            let child_fn_id = child_fn_id.clone();
+
+            async move {
+                *parent_run_state.lock().unwrap() = Some(input.ctx.run_id.clone());
+
+                let result: String = step.invoke(
+                    "invoke-child",
+                    InvokeFunctionOpts {
+                        function_id: child_fn_id,
+                        data: json!({ "message": "hello-from-child" }),
+                        timeout: None,
+                    },
+                )?;
+
+                *invoke_result_state.lock().unwrap() = Some(result.clone());
+
+                Ok(json!(result))
+            }
+        },
+    );
+
+    let app = spawn_app(client.clone(), vec![child_fn.into(), parent_fn.into()]).await;
+    app.sync().await;
+
+    client
+        .send_event(&Event::new(&parent_event_name, EmptyEventData {}))
+        .await
+        .expect("parent event should send successfully");
+
+    let run_id = wait_for_state(&parent_run_id, Duration::from_secs(5)).await;
+    let run = wait_for_run_status(&run_id, "Completed", Duration::from_secs(15)).await;
+
+    let result = wait_for_state(&invoke_result, Duration::from_secs(5)).await;
+    assert_eq!(result, "hello-from-child");
+    assert_eq!(run.output, json!("hello-from-child"));
+}

--- a/inngest/tests/invoke_e2e.rs
+++ b/inngest/tests/invoke_e2e.rs
@@ -25,6 +25,7 @@ struct InvokeEventData {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn step_invoke_returns_child_output() {
+    // The dev server uses fixed ports, so each e2e test holds the suite-wide lock.
     let _lock = DevServerLock::acquire();
     let _dev_server = DevServer::start().await;
 
@@ -55,8 +56,10 @@ async fn step_invoke_returns_child_output() {
             let child_fn_id = child_fn_id.clone();
 
             async move {
+                // Capture the parent run before the invoke step interrupts and resumes the function.
                 *parent_run_state.lock().unwrap() = Some(input.ctx.run_id.clone());
 
+                // The dev server returns the child output through the invoke envelope.
                 let result: String = step.invoke(
                     "invoke-child",
                     InvokeFunctionOpts {
@@ -76,6 +79,7 @@ async fn step_invoke_returns_child_output() {
     let app = spawn_app(client.clone(), vec![child_fn.into(), parent_fn.into()]).await;
     app.sync().await;
 
+    // Trigger the parent through the dev server so the invoke path uses the real control plane.
     client
         .send_event(&Event::new(&parent_event_name, EmptyEventData {}))
         .await
@@ -84,6 +88,7 @@ async fn step_invoke_returns_child_output() {
     let run_id = wait_for_state(&parent_run_id, Duration::from_secs(5)).await;
     let run = wait_for_run_status(&run_id, "Completed", Duration::from_secs(15)).await;
 
+    // Both the in-process state capture and the final run output should see the child payload.
     let result = wait_for_state(&invoke_result, Duration::from_secs(5)).await;
     assert_eq!(result, "hello-from-child");
     assert_eq!(run.output, json!("hello-from-child"));

--- a/inngest/tests/send_event_e2e.rs
+++ b/inngest/tests/send_event_e2e.rs
@@ -34,6 +34,7 @@ struct SendChildEventData {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn step_send_event_triggers_child_function() {
+    // The dev server uses fixed ports, so each e2e test holds the suite-wide lock.
     let _lock = DevServerLock::acquire();
     let _dev_server = DevServer::start().await;
 
@@ -77,8 +78,10 @@ async fn step_send_event_triggers_child_function() {
             let child_event_name = child_event_name_for_parent.clone();
 
             async move {
+                // Capture the parent run so the harness can poll the dev server for completion.
                 *parent_run_state.lock().unwrap() = Some(input.ctx.run_id.clone());
 
+                // `send_event` is durable, so the parent run is interrupted and replayed.
                 let ids = step
                     .send_event(
                         "send-child",
@@ -101,6 +104,7 @@ async fn step_send_event_triggers_child_function() {
     let app = spawn_app(client.clone(), vec![child_fn.into(), parent_fn.into()]).await;
     app.sync().await;
 
+    // Send the parent event through the dev server so the full SDK handshake is exercised.
     client
         .send_event(&Event::new(&parent_event_name, EmptyEventData {}))
         .await
@@ -112,10 +116,12 @@ async fn step_send_event_triggers_child_function() {
     let event_ids = wait_for_state(&sent_event_ids, Duration::from_secs(5)).await;
     assert_eq!(event_ids.len(), 1);
 
+    // The emitted child event should create its own completed run in the dev server.
     let child_runs = wait_for_event_runs(&event_ids[0], Duration::from_secs(10)).await;
     assert!(!child_runs[0].run_id.is_empty());
     assert_eq!(child_runs[0].status, "Completed");
 
+    // The child function should observe the durable event payload produced by the parent.
     let received = wait_for_state(&child_event, Duration::from_secs(10)).await;
     assert_eq!(received.id, event_ids[0]);
     assert_eq!(received.name, child_event_name);

--- a/inngest/tests/send_event_e2e.rs
+++ b/inngest/tests/send_event_e2e.rs
@@ -1,0 +1,124 @@
+mod e2e_support;
+
+use e2e_support::{
+    spawn_app, wait_for_event_runs, wait_for_run_status, wait_for_state, DevServer,
+    DevServerLock,
+};
+use inngest::{
+    client::Inngest,
+    event::Event,
+    function::{FunctionOpts, Input, ServableFn, Trigger},
+    result::Error,
+    step_tool::Step as StepTool,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+#[derive(Clone, Debug, Default)]
+struct ReceivedChildEvent {
+    id: String,
+    name: String,
+    message: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct EmptyEventData {}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct SendChildEventData {
+    message: String,
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn step_send_event_triggers_child_function() {
+    let _lock = DevServerLock::acquire();
+    let _dev_server = DevServer::start().await;
+
+    let app_name = e2e_support::unique_name("send-e2e-app");
+    let parent_event_name = e2e_support::unique_name("test.send.parent");
+    let child_event_name = e2e_support::unique_name("test.send.child");
+
+    let client = Inngest::new(&app_name).dev(e2e_support::DEV_SERVER_ORIGIN);
+    let parent_run_id = Arc::new(Mutex::new(None::<String>));
+    let sent_event_ids = Arc::new(Mutex::new(None::<Vec<String>>));
+    let child_event = Arc::new(Mutex::new(None::<ReceivedChildEvent>));
+
+    let child_state = Arc::clone(&child_event);
+    let child_fn: ServableFn<SendChildEventData, Error> = client.create_function(
+        FunctionOpts::new("send-child-fn").name("Send Child Fn"),
+        Trigger::event(&child_event_name),
+        move |input: Input<SendChildEventData>, _step: StepTool| {
+            let child_state = Arc::clone(&child_state);
+
+            async move {
+                *child_state.lock().unwrap() = Some(ReceivedChildEvent {
+                    id: input.event.id.unwrap_or_default(),
+                    name: input.event.name,
+                    message: input.event.data.message,
+                });
+
+                Ok(json!("child-complete"))
+            }
+        },
+    );
+
+    let parent_run_state = Arc::clone(&parent_run_id);
+    let sent_event_ids_state = Arc::clone(&sent_event_ids);
+    let child_event_name_for_parent = child_event_name.clone();
+    let parent_fn: ServableFn<EmptyEventData, Error> = client.create_function(
+        FunctionOpts::new("send-parent-fn").name("Send Parent Fn"),
+        Trigger::event(&parent_event_name),
+        move |input: Input<EmptyEventData>, step: StepTool| {
+            let parent_run_state = Arc::clone(&parent_run_state);
+            let sent_event_ids_state = Arc::clone(&sent_event_ids_state);
+            let child_event_name = child_event_name_for_parent.clone();
+
+            async move {
+                *parent_run_state.lock().unwrap() = Some(input.ctx.run_id.clone());
+
+                let ids = step
+                    .send_event(
+                        "send-child",
+                        Event::new(
+                            &child_event_name,
+                            SendChildEventData {
+                                message: "hello-from-parent".to_string(),
+                            },
+                        ),
+                    )
+                    .await?;
+
+                *sent_event_ids_state.lock().unwrap() = Some(ids.clone());
+
+                Ok(json!({ "event_ids": ids }))
+            }
+        },
+    );
+
+    let app = spawn_app(client.clone(), vec![child_fn.into(), parent_fn.into()]).await;
+    app.sync().await;
+
+    client
+        .send_event(&Event::new(&parent_event_name, EmptyEventData {}))
+        .await
+        .expect("parent event should send successfully");
+
+    let run_id = wait_for_state(&parent_run_id, Duration::from_secs(5)).await;
+    wait_for_run_status(&run_id, "Completed", Duration::from_secs(10)).await;
+
+    let event_ids = wait_for_state(&sent_event_ids, Duration::from_secs(5)).await;
+    assert_eq!(event_ids.len(), 1);
+
+    let child_runs = wait_for_event_runs(&event_ids[0], Duration::from_secs(10)).await;
+    assert!(!child_runs[0].run_id.is_empty());
+    assert_eq!(child_runs[0].status, "Completed");
+
+    let received = wait_for_state(&child_event, Duration::from_secs(10)).await;
+    assert_eq!(received.id, event_ids[0]);
+    assert_eq!(received.name, child_event_name);
+    assert_eq!(received.message, "hello-from-parent");
+}

--- a/inngest/tests/send_event_e2e.rs
+++ b/inngest/tests/send_event_e2e.rs
@@ -1,8 +1,7 @@
 mod e2e_support;
 
 use e2e_support::{
-    spawn_app, wait_for_event_runs, wait_for_run_status, wait_for_state, DevServer,
-    DevServerLock,
+    spawn_app, wait_for_event_runs, wait_for_run_status, wait_for_state, DevServer, DevServerLock,
 };
 use inngest::{
     client::Inngest,

--- a/inngest/tests/sleep_e2e.rs
+++ b/inngest/tests/sleep_e2e.rs
@@ -1,0 +1,87 @@
+mod e2e_support;
+
+use e2e_support::{spawn_app, wait_for_run_status, wait_for_state, DevServer, DevServerLock};
+use inngest::{
+    client::Inngest,
+    event::Event,
+    function::{FunctionOpts, Input, ServableFn, Trigger},
+    result::Error,
+    step_tool::Step as StepTool,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
+    time::{Duration, Instant},
+};
+
+#[derive(Debug, Deserialize, Serialize)]
+struct EmptyEventData {}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn step_sleep_pauses_and_resumes_the_run() {
+    let _lock = DevServerLock::acquire();
+    let _dev_server = DevServer::start().await;
+
+    let app_name = e2e_support::unique_name("sleep-e2e-app");
+    let sleep_event_name = e2e_support::unique_name("test.sleep.parent");
+    let sleep_duration = Duration::from_millis(1200);
+
+    let client = Inngest::new(&app_name).dev(e2e_support::DEV_SERVER_ORIGIN);
+    let run_id_state = Arc::new(Mutex::new(None::<String>));
+    let resumed_at_state = Arc::new(Mutex::new(None::<Instant>));
+    let handler_invocations = Arc::new(AtomicUsize::new(0));
+
+    let run_id_capture = Arc::clone(&run_id_state);
+    let resumed_at_capture = Arc::clone(&resumed_at_state);
+    let handler_invocations_capture = Arc::clone(&handler_invocations);
+    let sleep_fn: ServableFn<EmptyEventData, Error> = client.create_function(
+        FunctionOpts::new("sleep-fn").name("Sleep Fn"),
+        Trigger::event(&sleep_event_name),
+        move |input: Input<EmptyEventData>, step: StepTool| {
+            let run_id_capture = Arc::clone(&run_id_capture);
+            let resumed_at_capture = Arc::clone(&resumed_at_capture);
+            let handler_invocations_capture = Arc::clone(&handler_invocations_capture);
+
+            async move {
+                // The function body is replayed after the sleep completes, so count top-level calls.
+                handler_invocations_capture.fetch_add(1, Ordering::SeqCst);
+                *run_id_capture.lock().unwrap() = Some(input.ctx.run_id.clone());
+
+                // The first pass interrupts here; the second pass resumes and continues below.
+                step.sleep("pause-before-complete", sleep_duration)?;
+
+                *resumed_at_capture.lock().unwrap() = Some(Instant::now());
+
+                Ok(json!({ "slept": true }))
+            }
+        },
+    );
+
+    let app = spawn_app(client.clone(), vec![sleep_fn.into()]).await;
+    app.sync().await;
+
+    let sent_at = Instant::now();
+    client
+        .send_event(&Event::new(&sleep_event_name, EmptyEventData {}))
+        .await
+        .expect("sleep event should send successfully");
+
+    let run_id = wait_for_state(&run_id_state, Duration::from_secs(5)).await;
+
+    // A sleeping run should remain active before the scheduled resume fires.
+    wait_for_run_status(&run_id, "Running", Duration::from_secs(5)).await;
+
+    let run = wait_for_run_status(&run_id, "Completed", Duration::from_secs(10)).await;
+    let resumed_at = wait_for_state(&resumed_at_state, Duration::from_secs(5)).await;
+
+    assert!(
+        resumed_at.duration_since(sent_at) >= Duration::from_secs(1),
+        "sleep resumed too quickly"
+    );
+    assert_eq!(handler_invocations.load(Ordering::SeqCst), 2);
+    assert_eq!(run.output, json!({ "slept": true }));
+}

--- a/inngest/tests/step_run_e2e.rs
+++ b/inngest/tests/step_run_e2e.rs
@@ -1,0 +1,129 @@
+mod e2e_support;
+
+use e2e_support::{spawn_app, wait_for_run_status, wait_for_state, DevServer, DevServerLock};
+use inngest::{
+    client::Inngest,
+    event::Event,
+    function::{FunctionOpts, Input, ServableFn, Trigger},
+    result::{DevError, Error},
+    step_tool::Step as StepTool,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::{
+    fmt::{Display, Formatter},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
+    time::Duration,
+};
+
+#[derive(Debug, Deserialize, Serialize)]
+struct EmptyEventData {}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+struct MemoizedStepOutput {
+    message: String,
+    from_step: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct MemoizedStepFailure {
+    message: String,
+}
+
+impl Display for MemoizedStepFailure {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for MemoizedStepFailure {}
+
+impl From<MemoizedStepFailure> for Error {
+    fn from(err: MemoizedStepFailure) -> Self {
+        Error::Dev(DevError::Basic(err.message))
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn step_run_reuses_the_memoized_result_after_replay() {
+    // The dev server uses fixed ports, so each e2e test holds the suite-wide lock.
+    let _lock = DevServerLock::acquire();
+    let _dev_server = DevServer::start().await;
+
+    let app_name = e2e_support::unique_name("step-run-e2e-app");
+    let event_name = e2e_support::unique_name("test.step-run.parent");
+
+    let client = Inngest::new(&app_name).dev(e2e_support::DEV_SERVER_ORIGIN);
+    let run_id_state = Arc::new(Mutex::new(None::<String>));
+    let step_result_state = Arc::new(Mutex::new(None::<MemoizedStepOutput>));
+    let handler_invocations = Arc::new(AtomicUsize::new(0));
+    let step_invocations = Arc::new(AtomicUsize::new(0));
+
+    let run_id_capture = Arc::clone(&run_id_state);
+    let step_result_capture = Arc::clone(&step_result_state);
+    let handler_invocations_capture = Arc::clone(&handler_invocations);
+    let step_invocations_capture = Arc::clone(&step_invocations);
+    let step_run_fn: ServableFn<EmptyEventData, Error> = client.create_function(
+        FunctionOpts::new("step-run-fn").name("Step Run Fn"),
+        Trigger::event(&event_name),
+        move |input: Input<EmptyEventData>, step: StepTool| {
+            let run_id_capture = Arc::clone(&run_id_capture);
+            let step_result_capture = Arc::clone(&step_result_capture);
+            let handler_invocations_capture = Arc::clone(&handler_invocations_capture);
+            let step_invocations_capture = Arc::clone(&step_invocations_capture);
+
+            async move {
+                // The whole function replays after the first step interruption.
+                handler_invocations_capture.fetch_add(1, Ordering::SeqCst);
+                *run_id_capture.lock().unwrap() = Some(input.ctx.run_id.clone());
+
+                let step_result: MemoizedStepOutput = step
+                    .run("memoized-step", || {
+                        let step_invocations_capture = Arc::clone(&step_invocations_capture);
+
+                        async move {
+                            // The step body itself should execute only once.
+                            step_invocations_capture.fetch_add(1, Ordering::SeqCst);
+
+                            Ok::<_, MemoizedStepFailure>(MemoizedStepOutput {
+                                message: "hello-from-step".to_string(),
+                                from_step: true,
+                            })
+                        }
+                    })
+                    .await?;
+
+                *step_result_capture.lock().unwrap() = Some(step_result.clone());
+
+                Ok(json!(step_result))
+            }
+        },
+    );
+
+    let app = spawn_app(client.clone(), vec![step_run_fn.into()]).await;
+    app.sync().await;
+
+    // Trigger the function through the dev server so the real replay path is exercised.
+    client
+        .send_event(&Event::new(&event_name, EmptyEventData {}))
+        .await
+        .expect("step-run event should send successfully");
+
+    let run_id = wait_for_state(&run_id_state, Duration::from_secs(5)).await;
+    let run = wait_for_run_status(&run_id, "Completed", Duration::from_secs(10)).await;
+    let step_result = wait_for_state(&step_result_state, Duration::from_secs(5)).await;
+
+    let expected = MemoizedStepOutput {
+        message: "hello-from-step".to_string(),
+        from_step: true,
+    };
+
+    // The handler replays, but the memoized step body should not run twice.
+    assert_eq!(handler_invocations.load(Ordering::SeqCst), 2);
+    assert_eq!(step_invocations.load(Ordering::SeqCst), 1);
+    assert_eq!(step_result, expected);
+    assert_eq!(run.output, json!(expected));
+}

--- a/inngest/tests/wait_for_event_e2e.rs
+++ b/inngest/tests/wait_for_event_e2e.rs
@@ -1,0 +1,175 @@
+mod e2e_support;
+
+use e2e_support::{
+    spawn_app, wait_for_run_status, wait_for_state, DevServer, DevServerLock,
+};
+use inngest::{
+    client::Inngest,
+    event::Event,
+    function::{FunctionOpts, Input, ServableFn, Trigger},
+    result::Error,
+    step_tool::{Step as StepTool, WaitForEventOpts},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+#[derive(Clone, Debug, Default)]
+struct WaitForEventMatch {
+    id: String,
+    value: u32,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct WaitForEventData {
+    value: u32,
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wait_for_event_returns_the_fulfilled_event() {
+    let _lock = DevServerLock::acquire();
+    let _dev_server = DevServer::start().await;
+
+    let app_name = e2e_support::unique_name("wait-match-app");
+    let base_event_name = e2e_support::unique_name("test.wait.match");
+    let fulfill_event_name = format!("{base_event_name}.fulfilled");
+
+    let client = Inngest::new(&app_name).dev(e2e_support::DEV_SERVER_ORIGIN);
+    let run_id_state = Arc::new(Mutex::new(None::<String>));
+    let waited_event_state = Arc::new(Mutex::new(None::<WaitForEventMatch>));
+
+    let run_id_capture = Arc::clone(&run_id_state);
+    let waited_event_capture = Arc::clone(&waited_event_state);
+    let fulfill_event_name_for_wait = fulfill_event_name.clone();
+    let wait_fn: ServableFn<WaitForEventData, Error> = client.create_function(
+        FunctionOpts::new("wait-for-event-match-fn").name("Wait For Event Match Fn"),
+        Trigger::event(&base_event_name),
+        move |input: Input<WaitForEventData>, step: StepTool| {
+            let run_id_capture = Arc::clone(&run_id_capture);
+            let waited_event_capture = Arc::clone(&waited_event_capture);
+            let fulfill_event_name = fulfill_event_name_for_wait.clone();
+
+            async move {
+                *run_id_capture.lock().unwrap() = Some(input.ctx.run_id.clone());
+
+                let waited_event = step.wait_for_event::<WaitForEventData>(
+                    "wait-for-match",
+                    WaitForEventOpts {
+                        event: fulfill_event_name,
+                        timeout: Duration::from_secs(10),
+                        if_exp: Some("event.data.value == async.data.value".to_string()),
+                    },
+                )?;
+
+                if let Some(waited_event) = waited_event {
+                    *waited_event_capture.lock().unwrap() = Some(WaitForEventMatch {
+                        id: waited_event.id.unwrap_or_default(),
+                        value: waited_event.data.value,
+                    });
+
+                    Ok(json!("fulfilled"))
+                } else {
+                    Ok(json!("empty"))
+                }
+            }
+        },
+    );
+
+    let app = spawn_app(client.clone(), vec![wait_fn.into()]).await;
+    app.sync().await;
+
+    client
+        .send_event(&Event::new(
+            &base_event_name,
+            WaitForEventData { value: 42 },
+        ))
+        .await
+        .expect("base event should send successfully");
+
+    let run_id = wait_for_state(&run_id_state, Duration::from_secs(5)).await;
+    wait_for_run_status(&run_id, "Running", Duration::from_secs(10)).await;
+
+    client
+        .send_event(&Event::new(
+            &fulfill_event_name,
+            WaitForEventData { value: 42 },
+        ))
+        .await
+        .expect("fulfillment event should send successfully");
+
+    let run = wait_for_run_status(&run_id, "Completed", Duration::from_secs(10)).await;
+    let waited_event = wait_for_state(&waited_event_state, Duration::from_secs(10)).await;
+
+    assert!(!waited_event.id.is_empty());
+    assert_eq!(waited_event.value, 42);
+    assert_eq!(run.output, json!("fulfilled"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wait_for_event_times_out_without_a_match() {
+    let _lock = DevServerLock::acquire();
+    let _dev_server = DevServer::start().await;
+
+    let app_name = e2e_support::unique_name("wait-timeout-app");
+    let base_event_name = e2e_support::unique_name("test.wait.timeout");
+    let missing_event_name = format!("{base_event_name}.never");
+
+    let client = Inngest::new(&app_name).dev(e2e_support::DEV_SERVER_ORIGIN);
+    let run_id_state = Arc::new(Mutex::new(None::<String>));
+    let waited_event_state = Arc::new(Mutex::new(None::<WaitForEventMatch>));
+
+    let run_id_capture = Arc::clone(&run_id_state);
+    let waited_event_capture = Arc::clone(&waited_event_state);
+    let wait_fn: ServableFn<WaitForEventData, Error> = client.create_function(
+        FunctionOpts::new("wait-for-event-timeout-fn").name("Wait For Event Timeout Fn"),
+        Trigger::event(&base_event_name),
+        move |input: Input<WaitForEventData>, step: StepTool| {
+            let run_id_capture = Arc::clone(&run_id_capture);
+            let waited_event_capture = Arc::clone(&waited_event_capture);
+            let missing_event_name = missing_event_name.clone();
+
+            async move {
+                *run_id_capture.lock().unwrap() = Some(input.ctx.run_id.clone());
+
+                let waited_event = step.wait_for_event::<WaitForEventData>(
+                    "wait-for-timeout",
+                    WaitForEventOpts {
+                        event: missing_event_name,
+                        timeout: Duration::from_secs(1),
+                        if_exp: None,
+                    },
+                )?;
+
+                if let Some(waited_event) = waited_event {
+                    *waited_event_capture.lock().unwrap() = Some(WaitForEventMatch {
+                        id: waited_event.id.unwrap_or_default(),
+                        value: waited_event.data.value,
+                    });
+                    Ok(json!("fulfilled"))
+                } else {
+                    Ok(json!("empty"))
+                }
+            }
+        },
+    );
+
+    let app = spawn_app(client.clone(), vec![wait_fn.into()]).await;
+    app.sync().await;
+
+    client
+        .send_event(&Event::new(
+            &base_event_name,
+            WaitForEventData { value: 7 },
+        ))
+        .await
+        .expect("base event should send successfully");
+
+    let run_id = wait_for_state(&run_id_state, Duration::from_secs(5)).await;
+    let run = wait_for_run_status(&run_id, "Completed", Duration::from_secs(10)).await;
+
+    assert!(waited_event_state.lock().unwrap().is_none());
+    assert_eq!(run.output, json!("empty"));
+}

--- a/inngest/tests/wait_for_event_e2e.rs
+++ b/inngest/tests/wait_for_event_e2e.rs
@@ -28,6 +28,7 @@ struct WaitForEventData {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn wait_for_event_returns_the_fulfilled_event() {
+    // The fixed-port dev server is shared, so keep the e2e suite serialized.
     let _lock = DevServerLock::acquire();
     let _dev_server = DevServer::start().await;
 
@@ -51,8 +52,10 @@ async fn wait_for_event_returns_the_fulfilled_event() {
             let fulfill_event_name = fulfill_event_name_for_wait.clone();
 
             async move {
+                // Store the run ID before the wait step interrupts execution.
                 *run_id_capture.lock().unwrap() = Some(input.ctx.run_id.clone());
 
+                // The run should suspend until a matching event arrives or the timeout elapses.
                 let waited_event = step.wait_for_event::<WaitForEventData>(
                     "wait-for-match",
                     WaitForEventOpts {
@@ -87,6 +90,7 @@ async fn wait_for_event_returns_the_fulfilled_event() {
         .await
         .expect("base event should send successfully");
 
+    // The run should remain active while it is waiting for the second event.
     let run_id = wait_for_state(&run_id_state, Duration::from_secs(5)).await;
     wait_for_run_status(&run_id, "Running", Duration::from_secs(10)).await;
 
@@ -101,6 +105,7 @@ async fn wait_for_event_returns_the_fulfilled_event() {
     let run = wait_for_run_status(&run_id, "Completed", Duration::from_secs(10)).await;
     let waited_event = wait_for_state(&waited_event_state, Duration::from_secs(10)).await;
 
+    // The resumed function should receive the exact event that satisfied the wait expression.
     assert!(!waited_event.id.is_empty());
     assert_eq!(waited_event.value, 42);
     assert_eq!(run.output, json!("fulfilled"));
@@ -108,6 +113,7 @@ async fn wait_for_event_returns_the_fulfilled_event() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn wait_for_event_times_out_without_a_match() {
+    // The fixed-port dev server is shared, so keep the e2e suite serialized.
     let _lock = DevServerLock::acquire();
     let _dev_server = DevServer::start().await;
 
@@ -130,6 +136,7 @@ async fn wait_for_event_times_out_without_a_match() {
             let missing_event_name = missing_event_name.clone();
 
             async move {
+                // Store the run ID before the wait step interrupts execution.
                 *run_id_capture.lock().unwrap() = Some(input.ctx.run_id.clone());
 
                 let waited_event = step.wait_for_event::<WaitForEventData>(
@@ -165,6 +172,7 @@ async fn wait_for_event_times_out_without_a_match() {
     let run_id = wait_for_state(&run_id_state, Duration::from_secs(5)).await;
     let run = wait_for_run_status(&run_id, "Completed", Duration::from_secs(10)).await;
 
+    // A timed-out wait should resume with `None` and let the function decide the fallback output.
     assert!(waited_event_state.lock().unwrap().is_none());
     assert_eq!(run.output, json!("empty"));
 }

--- a/inngest/tests/wait_for_event_e2e.rs
+++ b/inngest/tests/wait_for_event_e2e.rs
@@ -1,8 +1,6 @@
 mod e2e_support;
 
-use e2e_support::{
-    spawn_app, wait_for_run_status, wait_for_state, DevServer, DevServerLock,
-};
+use e2e_support::{spawn_app, wait_for_run_status, wait_for_state, DevServer, DevServerLock};
 use inngest::{
     client::Inngest,
     event::Event,
@@ -160,10 +158,7 @@ async fn wait_for_event_times_out_without_a_match() {
     app.sync().await;
 
     client
-        .send_event(&Event::new(
-            &base_event_name,
-            WaitForEventData { value: 7 },
-        ))
+        .send_event(&Event::new(&base_event_name, WaitForEventData { value: 7 }))
         .await
         .expect("base event should send successfully");
 

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+mapfile -t tests < <(find inngest/tests -maxdepth 1 -type f -name '*_e2e.rs' | sort)
+
+if [[ "${#tests[@]}" -eq 0 ]]; then
+  echo "No e2e test files found under inngest/tests" >&2
+  exit 1
+fi
+
+for test_file in "${tests[@]}"; do
+  test_name="$(basename "${test_file%.rs}")"
+  echo "Running ${test_name}"
+  cargo test -p inngest --test "$test_name" -- --test-threads=1
+done


### PR DESCRIPTION
resolves #37 

## Summary
- add dev-server end-to-end coverage for `send_event`, `wait_for_event`, `invoke`, `sleep`, and `step.run`
- split the e2e suite into focused test files with a shared harness and extra inline comments to make the flow easier to follow
- run the integration suite in CI via a dedicated `e2e` job using the Nix dev shell and a discovered `make test-e2e` target
- fix SDK behavior exposed by the new coverage, including dev sync URL normalization and invoke response decoding from dev-server envelopes

## Testing
- `cargo test -p inngest --test step_run_e2e --test sleep_e2e --test send_event_e2e --test wait_for_event_e2e --test invoke_e2e -- --test-threads=1`
- `make test-e2e`