### PR TITLE
fix(handler): harden signature verification and mode selection

### DIFF
--- a/docs/plans/001-signature-and-mode-hardening.org
+++ b/docs/plans/001-signature-and-mode-hardening.org
@@ -15,32 +15,32 @@
 - Introspection auth metadata
 
 ** Checklist
-- [x] Stop deriving effective mode from incoming server headers
-- [x] Use SDK configuration and environment to decide cloud vs dev behavior
-- [x] Keep sync targeting driven by configured mode and configured origins, not triggering request headers
-- [x] Reject cloud-mode requests when no signing key is configured
-- [x] Enforce signature presence for cloud mode requests
-- [x] Allow missing signatures in dev mode while still validating when a signature is present
-- [x] Always validate introspection signatures when present and return authenticated vs unauthenticated payloads accordingly
-- [x] Add support for `INNGEST_SIGNING_KEY_FALLBACK`
-- [x] Try the fallback signing key when primary verification fails
-- [x] Reuse fallback behavior for outbound authenticated API calls
-- [x] Preserve outbound auth header requirements when touching authenticated API calls (`Authorization`, `X-Inngest-Sdk`, `X-Inngest-Req-Version`, `X-Inngest-Env` when available)
-- [x] Report fallback signing key presence in introspection responses
-- [x] Report fallback signing key hash in authenticated introspection responses
-- [x] Populate introspection `env` when available
-- [x] Keep introspection auth metadata schema-limited to spec-defined top-level fields
-- [x] Add tests for cloud/dev verification behavior
-- [x] Add tests for cloud-mode missing-signing-key and missing-signature failure paths
-- [x] Add tests for primary-key and fallback-key verification paths
-- [x] Add tests proving configured mode, not inbound headers, drives sync target selection
+- [X] Stop deriving effective mode from incoming server headers
+- [X] Use SDK configuration and environment to decide cloud vs dev behavior
+- [X] Keep sync targeting driven by configured mode and configured origins, not triggering request headers
+- [X] Reject cloud-mode requests when no signing key is configured
+- [X] Enforce signature presence for cloud mode requests
+- [X] Allow missing signatures in dev mode while still validating when a signature is present
+- [X] Always validate introspection signatures when present and return authenticated vs unauthenticated payloads accordingly
+- [X] Add support for `INNGEST_SIGNING_KEY_FALLBACK`
+- [X] Try the fallback signing key when primary verification fails
+- [X] Reuse fallback behavior for outbound authenticated API calls
+- [X] Preserve outbound auth header requirements when touching authenticated API calls (`Authorization`, `X-Inngest-Sdk`, `X-Inngest-Req-Version`, `X-Inngest-Env` when available)
+- [X] Report fallback signing key presence in introspection responses
+- [X] Report fallback signing key hash in authenticated introspection responses
+- [X] Populate introspection `env` when available
+- [X] Keep introspection auth metadata schema-limited to spec-defined top-level fields
+- [X] Add tests for cloud/dev verification behavior
+- [X] Add tests for cloud-mode missing-signing-key and missing-signature failure paths
+- [X] Add tests for primary-key and fallback-key verification paths
+- [X] Add tests proving configured mode, not inbound headers, drives sync target selection
 
 ** Exit Criteria
-- [x] Incoming request verification is driven by configured mode, not request headers
-- [x] Sync targeting and outbound auth selection are driven by configured mode/origins, not request headers
-- [x] Cloud-mode failures for missing signing key and missing signature match spec expectations
-- [x] Fallback key logic works for both verification and outbound auth
-- [x] Introspection accurately reports auth-related state without leaking non-spec top-level fields
+- [X] Incoming request verification is driven by configured mode, not request headers
+- [X] Sync targeting and outbound auth selection are driven by configured mode/origins, not request headers
+- [X] Cloud-mode failures for missing signing key and missing signature match spec expectations
+- [X] Fallback key logic works for both verification and outbound auth
+- [X] Introspection accurately reports auth-related state without leaking non-spec top-level fields
 
 ** Out of Scope
 - Full call-request execution semantics

--- a/docs/plans/001-signature-and-mode-hardening.org
+++ b/docs/plans/001-signature-and-mode-hardening.org
@@ -9,6 +9,7 @@
 
 ** Scope
 - Mode selection
+- Config-driven server targeting for sync/authenticated API calls
 - Signature verification rules
 - Signing key fallback support
 - Introspection auth metadata
@@ -16,23 +17,33 @@
 ** Checklist
 - [ ] Stop deriving effective mode from incoming server headers
 - [ ] Use SDK configuration and environment to decide cloud vs dev behavior
+- [ ] Keep sync targeting driven by configured mode and configured origins, not triggering request headers
+- [ ] Reject cloud-mode requests when no signing key is configured
 - [ ] Enforce signature presence for cloud mode requests
 - [ ] Allow missing signatures in dev mode while still validating when a signature is present
+- [ ] Always validate introspection signatures when present and return authenticated vs unauthenticated payloads accordingly
 - [ ] Add support for `INNGEST_SIGNING_KEY_FALLBACK`
 - [ ] Try the fallback signing key when primary verification fails
 - [ ] Reuse fallback behavior for outbound authenticated API calls
+- [ ] Preserve outbound auth header requirements when touching authenticated API calls (`Authorization`, `X-Inngest-Sdk`, `X-Inngest-Req-Version`, `X-Inngest-Env` when available)
 - [ ] Report fallback signing key presence in introspection responses
 - [ ] Report fallback signing key hash in authenticated introspection responses
 - [ ] Populate introspection `env` when available
+- [ ] Keep introspection auth metadata schema-limited to spec-defined top-level fields
 - [ ] Add tests for cloud/dev verification behavior
+- [ ] Add tests for cloud-mode missing-signing-key and missing-signature failure paths
 - [ ] Add tests for primary-key and fallback-key verification paths
+- [ ] Add tests proving configured mode, not inbound headers, drives sync target selection
 
 ** Exit Criteria
 - [ ] Incoming request verification is driven by configured mode, not request headers
+- [ ] Sync targeting and outbound auth selection are driven by configured mode/origins, not request headers
+- [ ] Cloud-mode failures for missing signing key and missing signature match spec expectations
 - [ ] Fallback key logic works for both verification and outbound auth
-- [ ] Introspection accurately reports auth-related state
+- [ ] Introspection accurately reports auth-related state without leaking non-spec top-level fields
 
 ** Out of Scope
 - Full call-request execution semantics
 - Middleware
 - Connect
+- Dev-mode warning behavior for unexpected `X-Inngest-Server-Kind` values

--- a/docs/plans/001-signature-and-mode-hardening.org
+++ b/docs/plans/001-signature-and-mode-hardening.org
@@ -1,6 +1,6 @@
 #+AUTHOR: Darwin D. Wu
 #+DATE: 2026-04-16
-#+STATUS: Draft
+#+STATUS: Done
 
 * Milestone 001: Signature and Mode Hardening
 
@@ -15,32 +15,32 @@
 - Introspection auth metadata
 
 ** Checklist
-- [ ] Stop deriving effective mode from incoming server headers
-- [ ] Use SDK configuration and environment to decide cloud vs dev behavior
-- [ ] Keep sync targeting driven by configured mode and configured origins, not triggering request headers
-- [ ] Reject cloud-mode requests when no signing key is configured
-- [ ] Enforce signature presence for cloud mode requests
-- [ ] Allow missing signatures in dev mode while still validating when a signature is present
-- [ ] Always validate introspection signatures when present and return authenticated vs unauthenticated payloads accordingly
-- [ ] Add support for `INNGEST_SIGNING_KEY_FALLBACK`
-- [ ] Try the fallback signing key when primary verification fails
-- [ ] Reuse fallback behavior for outbound authenticated API calls
-- [ ] Preserve outbound auth header requirements when touching authenticated API calls (`Authorization`, `X-Inngest-Sdk`, `X-Inngest-Req-Version`, `X-Inngest-Env` when available)
-- [ ] Report fallback signing key presence in introspection responses
-- [ ] Report fallback signing key hash in authenticated introspection responses
-- [ ] Populate introspection `env` when available
-- [ ] Keep introspection auth metadata schema-limited to spec-defined top-level fields
-- [ ] Add tests for cloud/dev verification behavior
-- [ ] Add tests for cloud-mode missing-signing-key and missing-signature failure paths
-- [ ] Add tests for primary-key and fallback-key verification paths
-- [ ] Add tests proving configured mode, not inbound headers, drives sync target selection
+- [x] Stop deriving effective mode from incoming server headers
+- [x] Use SDK configuration and environment to decide cloud vs dev behavior
+- [x] Keep sync targeting driven by configured mode and configured origins, not triggering request headers
+- [x] Reject cloud-mode requests when no signing key is configured
+- [x] Enforce signature presence for cloud mode requests
+- [x] Allow missing signatures in dev mode while still validating when a signature is present
+- [x] Always validate introspection signatures when present and return authenticated vs unauthenticated payloads accordingly
+- [x] Add support for `INNGEST_SIGNING_KEY_FALLBACK`
+- [x] Try the fallback signing key when primary verification fails
+- [x] Reuse fallback behavior for outbound authenticated API calls
+- [x] Preserve outbound auth header requirements when touching authenticated API calls (`Authorization`, `X-Inngest-Sdk`, `X-Inngest-Req-Version`, `X-Inngest-Env` when available)
+- [x] Report fallback signing key presence in introspection responses
+- [x] Report fallback signing key hash in authenticated introspection responses
+- [x] Populate introspection `env` when available
+- [x] Keep introspection auth metadata schema-limited to spec-defined top-level fields
+- [x] Add tests for cloud/dev verification behavior
+- [x] Add tests for cloud-mode missing-signing-key and missing-signature failure paths
+- [x] Add tests for primary-key and fallback-key verification paths
+- [x] Add tests proving configured mode, not inbound headers, drives sync target selection
 
 ** Exit Criteria
-- [ ] Incoming request verification is driven by configured mode, not request headers
-- [ ] Sync targeting and outbound auth selection are driven by configured mode/origins, not request headers
-- [ ] Cloud-mode failures for missing signing key and missing signature match spec expectations
-- [ ] Fallback key logic works for both verification and outbound auth
-- [ ] Introspection accurately reports auth-related state without leaking non-spec top-level fields
+- [x] Incoming request verification is driven by configured mode, not request headers
+- [x] Sync targeting and outbound auth selection are driven by configured mode/origins, not request headers
+- [x] Cloud-mode failures for missing signing key and missing signature match spec expectations
+- [x] Fallback key logic works for both verification and outbound auth
+- [x] Introspection accurately reports auth-related state without leaking non-spec top-level fields
 
 ** Out of Scope
 - Full call-request execution semantics

--- a/inngest/src/client.rs
+++ b/inngest/src/client.rs
@@ -44,11 +44,7 @@ impl Inngest {
         let event_api_origin = Config::event_api_origin();
         let event_key = Config::event_key();
         let env = Config::env();
-        // if the value is a URL, use it. otherwise set a default URL
-        let dev = Config::dev().map(|v| match Url::parse(&v) {
-            Ok(val) => val.to_string(),
-            Err(_) => API_ORIGIN_DEV.to_string(),
-        });
+        let dev = Config::dev().and_then(|v| Self::normalize_dev_value(&v));
 
         Inngest {
             id: id.to_string(),
@@ -86,12 +82,16 @@ impl Inngest {
     }
 
     pub fn dev(mut self, dev: &str) -> Self {
-        let url = match Url::parse(dev) {
-            Ok(val) => Some(val.to_string()),
-            Err(_) => Some(API_ORIGIN_DEV.to_string()),
-        };
-        self.dev = url;
+        self.dev = Self::normalize_dev_value(dev).or_else(|| Some(API_ORIGIN_DEV.to_string()));
         self
+    }
+
+    pub(crate) fn mode(&self) -> Kind {
+        if self.dev.is_some() {
+            Kind::Dev
+        } else {
+            Kind::Cloud
+        }
     }
 
     pub fn create_function<
@@ -204,7 +204,7 @@ impl Inngest {
         }
     }
 
-    pub(crate) fn inngest_api_origin(&self, kind: Kind) -> String {
+    pub(crate) fn inngest_api_origin(&self) -> String {
         if let Some(dev) = self.dev.clone() {
             return dev;
         }
@@ -213,10 +213,49 @@ impl Inngest {
             return endpoint;
         }
 
-        match kind {
+        match self.mode() {
             Kind::Dev => API_ORIGIN_DEV.to_string(),
             Kind::Cloud => API_ORIGIN.to_string(),
         }
+    }
+
+    fn normalize_dev_value(value: &str) -> Option<String> {
+        let value = value.trim();
+        if value.is_empty() || value == "0" {
+            return None;
+        }
+
+        match Url::parse(value) {
+            Ok(val) => Some(val.to_string()),
+            Err(_) => Some(API_ORIGIN_DEV.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod dev_mode_tests {
+    use super::*;
+
+    #[test]
+    fn normalize_dev_value_treats_zero_as_cloud_mode() {
+        assert_eq!(Inngest::normalize_dev_value("0"), None);
+        assert_eq!(Inngest::normalize_dev_value(""), None);
+    }
+
+    #[test]
+    fn normalize_dev_value_uses_default_dev_origin_for_non_zero_flags() {
+        assert_eq!(
+            Inngest::normalize_dev_value("1"),
+            Some(API_ORIGIN_DEV.to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_dev_value_preserves_explicit_dev_origin() {
+        assert_eq!(
+            Inngest::normalize_dev_value("http://example.com"),
+            Some("http://example.com/".to_string())
+        );
     }
 }
 

--- a/inngest/src/config.rs
+++ b/inngest/src/config.rs
@@ -9,6 +9,7 @@ const INNGEST_DEV: &str = "INNGEST_DEV";
 
 // server side
 const INNGEST_SIGNING_KEY: &str = "INNGEST_SIGNING_KEY";
+const INNGEST_SIGNING_KEY_FALLBACK: &str = "INNGEST_SIGNING_KEY_FALLBACK";
 const INNGEST_SERVE_ORIGIN: &str = "INNGEST_SERVE_ORIGIN";
 const INNGEST_SERVE_PATH: &str = "INNGEST_SERVE_PATH";
 
@@ -37,6 +38,10 @@ impl Config {
 
     pub fn signing_key() -> Option<String> {
         Self::read_env_str(INNGEST_SIGNING_KEY)
+    }
+
+    pub fn signing_key_fallback() -> Option<String> {
+        Self::read_env_str(INNGEST_SIGNING_KEY_FALLBACK)
     }
 
     pub fn serve_origin() -> Option<String> {

--- a/inngest/src/handler.rs
+++ b/inngest/src/handler.rs
@@ -13,11 +13,12 @@ use crate::{
     config::Config,
     event::{Event, InngestEvent},
     function::{Function, FunctionOpts, Input, InputCtx, ServableFn, Trigger},
-    header::Headers,
+    header::{self, Headers},
     result::{Error, FlowControlVariant, SdkResponse},
     sdk::Request,
     signature::Signature,
     step_tool::Step as StepTool,
+    version::{self, EXECUTION_VERSION},
 };
 
 type DynamicFn =
@@ -213,7 +214,7 @@ where
 pub struct Handler {
     inngest: Inngest,
     signing_key: Option<String>,
-    // TODO: signing_key_fallback
+    signing_key_fallback: Option<String>,
     serve_origin: Option<String>,
     serve_path: Option<String>,
     funcs: HashMap<String, DynamicServableFn>,
@@ -236,21 +237,14 @@ impl Handler {
     /// Creates a new handler for the given Inngest client.
     pub fn new(client: &Inngest) -> Self {
         let signing_key = Config::signing_key();
+        let signing_key_fallback = Config::signing_key_fallback();
         let serve_origin = Config::serve_origin();
         let serve_path = Config::serve_path();
-        let mode = match client.dev.clone() {
-            None => Kind::Cloud,
-            Some(v) => {
-                if v != "0" {
-                    Kind::Dev
-                } else {
-                    Kind::Cloud
-                }
-            }
-        };
+        let mode = client.mode();
 
         Handler {
             signing_key,
+            signing_key_fallback,
             serve_origin,
             serve_path,
             inngest: client.clone(),
@@ -262,6 +256,12 @@ impl Handler {
     /// Overrides the signing key used to verify inbound requests.
     pub fn signing_key(mut self, key: &str) -> Self {
         self.signing_key = Some(key.to_string());
+        self
+    }
+
+    /// Overrides the fallback signing key used after primary-key auth fails.
+    pub fn signing_key_fallback(mut self, key: &str) -> Self {
+        self.signing_key_fallback = Some(key.to_string());
         self
     }
 
@@ -345,7 +345,17 @@ impl Handler {
         };
 
         let signature = Signature::new(&key).sig(sig).body(raw_body);
-        signature.verify(false)
+        match signature.verify(false) {
+            Ok(_) => Ok(()),
+            Err(err) => {
+                if let Some(fallback) = self.signing_key_fallback.clone() {
+                    let signature = Signature::new(&fallback).sig(sig).body(raw_body);
+                    signature.verify(false)
+                } else {
+                    Err(err)
+                }
+            }
+        }
     }
 
     pub async fn introspect(
@@ -360,86 +370,65 @@ impl Handler {
         let has_signing_key = self.has_signing_key();
         let has_signing_key_fallback = self.has_signing_key_fallback();
         let schema_version = PROBE_SCHEMA_VERSION.to_string();
+        let authentication_succeeded = match headers.signature() {
+            Some(sig) => Some(self.verify_signature(&sig, raw_body).is_ok()),
+            None => None,
+        };
 
-        let mut authentication_succeeded: Option<bool> = None;
+        if authentication_succeeded == Some(true) {
+            let api_origin = match self.inngest.api_origin.clone() {
+                Some(origin) => origin,
+                None => client::API_ORIGIN.to_string(),
+            };
 
-        match self.mode {
-            Kind::Dev => Ok(IntrospectResult::Unauthenticated(Box::new(
-                IntrospectUnauthedResult {
-                    authentication_succeeded,
+            let event_api_origin = match self.inngest.event_api_origin.clone() {
+                Some(origin) => origin,
+                None => client::EVENT_API_ORIGIN.to_string(),
+            };
+
+            let event_key_hash = self.hash_key(self.inngest.event_key.clone());
+            let signing_key_hash = self.hashed_signing_key(self.signing_key.clone());
+            let signing_key_fallback_hash =
+                self.hashed_signing_key(self.signing_key_fallback.clone());
+
+            return Ok(IntrospectResult::Authenticated(Box::new(
+                IntrospectAuthedResult {
+                    app_id: self.inngest.app_id(),
+                    api_origin,
+                    event_api_origin,
+                    event_key_hash,
+                    authentication_succeeded: true,
+                    env: self.inngest.env.clone(),
                     extra: None,
+                    framework: framework.to_string(),
                     function_count,
                     has_event_key,
                     has_signing_key,
                     has_signing_key_fallback,
-                    mode: Kind::Dev,
+                    mode: self.mode.clone(),
                     schema_version,
+                    sdk_language: "rust".to_string(),
+                    sdk_version: env!("CARGO_PKG_VERSION").to_string(),
+                    serve_origin: self.serve_origin.clone(),
+                    serve_path: self.serve_path.clone(),
+                    signing_key_hash,
+                    signing_key_fallback_hash,
                 },
-            ))),
-
-            Kind::Cloud => {
-                if let Some(sig) = headers.signature() {
-                    if self.verify_signature(&sig, raw_body).is_ok() {
-                        let api_origin = match self.inngest.api_origin.clone() {
-                            Some(origin) => origin,
-                            None => client::API_ORIGIN.to_string(),
-                        };
-
-                        let event_api_origin = match self.inngest.event_api_origin.clone() {
-                            Some(origin) => origin,
-                            None => client::EVENT_API_ORIGIN.to_string(),
-                        };
-
-                        let event_key_hash = self.hash_key(self.inngest.event_key.clone());
-                        let signing_key_hash = if let Some(key) = self.signing_key.clone() {
-                            Signature::new(&key).hash().ok()
-                        } else {
-                            None
-                        };
-
-                        return Ok(IntrospectResult::Authenticated(Box::new(
-                            IntrospectAuthedResult {
-                                app_id: self.inngest.app_id(),
-                                api_origin,
-                                event_api_origin,
-                                event_key_hash,
-                                authentication_succeeded: true,
-                                env: None, // TODO
-                                extra: None,
-                                framework: framework.to_string(),
-                                function_count,
-                                has_event_key,
-                                has_signing_key,
-                                has_signing_key_fallback,
-                                mode: Kind::Cloud,
-                                schema_version,
-                                sdk_language: "rust".to_string(),
-                                sdk_version: env!("CARGO_PKG_VERSION").to_string(),
-                                serve_origin: self.serve_origin.clone(),
-                                serve_path: self.serve_path.clone(),
-                                signing_key_hash,
-                                signing_key_fallback_hash: None, // TODO
-                            },
-                        )));
-                    };
-                    // mark it as false
-                    authentication_succeeded = Some(false);
-                }
-
-                Ok(IntrospectResult::Unauthenticated(Box::new(
-                    IntrospectUnauthedResult {
-                        authentication_succeeded,
-                        extra: None,
-                        function_count,
-                        has_event_key,
-                        has_signing_key,
-                        has_signing_key_fallback,
-                        mode: Kind::Cloud,
-                        schema_version,
-                    },
-                )))
-            }
+            )));
         }
+
+        Ok(IntrospectResult::Unauthenticated(Box::new(
+            IntrospectUnauthedResult {
+                authentication_succeeded,
+                extra: None,
+                function_count,
+                has_event_key,
+                has_signing_key,
+                has_signing_key_fallback,
+                mode: self.mode.clone(),
+                schema_version,
+            },
+        )))
     }
 
     fn has_event_key(&self) -> bool {
@@ -451,7 +440,7 @@ impl Handler {
     }
 
     fn has_signing_key_fallback(&self) -> bool {
-        false
+        self.signing_key_fallback.is_some()
     }
 
     fn hash_key(&self, key: Option<String>) -> Option<String> {
@@ -462,6 +451,10 @@ impl Handler {
             let sum = hasher.finalize();
             base16::encode_lower(&sum)
         })
+    }
+
+    fn hashed_signing_key(&self, key: Option<String>) -> Option<String> {
+        key.and_then(|key| Signature::new(&key).hash().ok())
     }
 
     fn sync_payload(&self, headers: &Headers, framework: &str) -> Request {
@@ -487,74 +480,60 @@ impl Handler {
 
     pub async fn sync(
         &self,
-        headers: &Headers,
+        _headers: &Headers,
         query: &SyncQueryParams,
         framework: &str,
     ) -> Result<SyncResponse, String> {
-        let kind = headers.server_kind();
-        let req = self.sync_payload(headers, framework);
+        let req = self.sync_payload(_headers, framework);
+        let sync_url = format!("{}/fn/register", self.inngest.inngest_api_origin().trim_end_matches('/'));
 
-        let mut sync_req = reqwest::Client::new()
-            .post(format!(
-                "{}/fn/register",
-                self.inngest.inngest_api_origin(kind).trim_end_matches('/')
-            ))
-            .json(&req);
+        let mut resp = self
+            .send_sync_request(&sync_url, &req, query, self.signing_key.as_deref())
+            .await?;
 
-        if let Some(key) = &self.signing_key {
-            let sig = Signature::new(key);
-            match sig.hash() {
-                Ok(hashed) => {
-                    sync_req = sync_req.header("authorization", format!("Bearer {}", hashed));
-                }
-                Err(_err) => {
-                    return Err("error hashing signing key".to_string());
-                }
-            }
+        if resp.status().as_u16() == 401
+            && self.signing_key.is_some()
+            && self.signing_key_fallback.is_some()
+        {
+            resp = self
+                .send_sync_request(
+                    &sync_url,
+                    &req,
+                    query,
+                    self.signing_key_fallback.as_deref(),
+                )
+                .await?;
         }
 
-        if let Some(deploy_id) = query.deploy_id.clone() {
-            sync_req = sync_req.query(&[("deployId", &deploy_id)]);
-        }
-
-        match sync_req.send().await {
-            Ok(resp) => {
-                let status = resp.status();
-                let body = match resp.text().await {
-                    Ok(body) => body,
-                    Err(err) => {
-                        return Err(format!("error reading sync response: {}", err));
-                    }
-                };
-
-                if !status.is_success() {
-                    return Err(format!(
-                        "error registering: status {} body {}",
-                        status.as_u16(),
-                        body
-                    ));
-                }
-
-                match serde_json::from_str::<InngestSyncSuccess>(&body) {
-                    Ok(res) => {
-                        let modified: bool = res.modified.unwrap_or_default();
-
-                        Ok(SyncResponse::OutOfBand(Box::new(OutOfBandSyncResponse {
-                            message: "Successfully synced.".to_string(),
-                            modified,
-                        })))
-                    }
-                    Err(err) => Err(format!(
-                        "error parsing sync response: {} body {}",
-                        err, body
-                    )),
-                }
-            }
+        let status = resp.status();
+        let body = match resp.text().await {
+            Ok(body) => body,
             Err(err) => {
-                println!("ERROR: {:?}", err);
-
-                Err("error registering".to_string())
+                return Err(format!("error reading sync response: {}", err));
             }
+        };
+
+        if !status.is_success() {
+            return Err(format!(
+                "error registering: status {} body {}",
+                status.as_u16(),
+                body
+            ));
+        }
+
+        match serde_json::from_str::<InngestSyncSuccess>(&body) {
+            Ok(res) => {
+                let modified: bool = res.modified.unwrap_or_default();
+
+                Ok(SyncResponse::OutOfBand(Box::new(OutOfBandSyncResponse {
+                    message: "Successfully synced.".to_string(),
+                    modified,
+                })))
+            }
+            Err(err) => Err(format!(
+                "error parsing sync response: {} body {}",
+                err, body
+            )),
         }
     }
 
@@ -566,14 +545,22 @@ impl Handler {
         body: &Value,
     ) -> Result<SdkResponse, Error> {
         let sig = headers.signature();
-        let kind = headers.server_kind();
-        if kind == Kind::Cloud && sig.is_none() {
-            return Err(basic_error!("no signature provided for SDK in Cloud mode"));
-        }
+        if self.mode == Kind::Cloud {
+            if self.signing_key.is_none() {
+                return Err(basic_error!(
+                    "no signing key available for verifying request signature"
+                ));
+            }
 
-        // Verify the signature if provided
-        if let Some(sig) = sig.clone() {
+            let Some(sig) = sig.clone() else {
+                return Err(basic_error!("no signature provided for SDK in Cloud mode"));
+            };
+
             self.verify_signature(&sig, raw_body)?;
+        } else if let Some(sig) = sig.clone() {
+            if self.signing_key.is_some() {
+                self.verify_signature(&sig, raw_body)?;
+            }
         }
 
         // find the specified function
@@ -587,6 +574,40 @@ impl Handler {
         func.run(query.fn_id.clone(), body.clone()).await
     }
     // run the function
+
+    async fn send_sync_request(
+        &self,
+        sync_url: &str,
+        req: &Request,
+        query: &SyncQueryParams,
+        auth_key: Option<&str>,
+    ) -> Result<reqwest::Response, String> {
+        let mut sync_req = reqwest::Client::new()
+            .post(sync_url)
+            .json(req)
+            .header(header::INNGEST_SDK, version::sdk())
+            .header(header::INNGEST_REQ_VERSION, EXECUTION_VERSION);
+
+        if let Some(env) = self.inngest.env.clone() {
+            sync_req = sync_req.header(header::INNGEST_ENV, env);
+        }
+
+        if let Some(key) = auth_key {
+            let hashed = Signature::new(key)
+                .hash()
+                .map_err(|_| "error hashing signing key".to_string())?;
+            sync_req = sync_req.header("authorization", format!("Bearer {}", hashed));
+        }
+
+        if let Some(deploy_id) = query.deploy_id.clone() {
+            sync_req = sync_req.query(&[("deployId", &deploy_id)]);
+        }
+
+        sync_req.send().await.map_err(|err| {
+            println!("ERROR: {:?}", err);
+            "error registering".to_string()
+        })
+    }
 }
 
 #[derive(Deserialize, Debug)]
@@ -611,7 +632,7 @@ struct RunRequestCtx {
     // stack: RunRequestCtxStack,
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Kind {
     Dev,
@@ -699,8 +720,10 @@ mod tests {
     use super::*;
     use crate::function::ServableFn;
     use axum::http::HeaderMap;
+    use hmac::{Hmac, Mac};
     use serde::{Deserialize, Serialize};
     use std::collections::HashSet;
+    use sha2::Sha256;
 
     #[derive(Debug, Deserialize, Serialize)]
     struct FirstEvent {
@@ -712,9 +735,14 @@ mod tests {
         count: u32,
     }
 
+    const PRIMARY_SIGNING_KEY: &str =
+        "signkey-test-8ee2262a15e8d3c42d6a840db7af3de2aab08ef632b32a37a687f24b34dba3ff";
+    const FALLBACK_SIGNING_KEY: &str =
+        "signkey-test-1111111111111111111111111111111111111111111111111111111111111111";
+
     #[tokio::test]
     async fn handler_dispatches_functions_with_different_event_types() {
-        let client = Inngest::new("test-app");
+        let client = Inngest::new("test-app").dev("1");
         let mut handler = Handler::new(&client);
 
         let first_fn: ServableFn<FirstEvent, Error> = client.create_function(
@@ -794,7 +822,7 @@ mod tests {
 
     #[tokio::test]
     async fn handler_dispatches_functions_registered_via_mixed_apis() {
-        let client = Inngest::new("test-app");
+        let client = Inngest::new("test-app").dev("1");
         let mut handler = Handler::new(&client);
 
         let first_fn: ServableFn<FirstEvent, Error> = client.create_function(
@@ -846,7 +874,7 @@ mod tests {
 
     #[tokio::test]
     async fn handler_returns_error_for_unknown_function_id() {
-        let client = Inngest::new("test-app");
+        let client = Inngest::new("test-app").dev("1");
         let handler = Handler::new(&client);
         let headers = Headers::from(HeaderMap::new());
         let body = event_body("test/first", json!({ "message": "hello" }));
@@ -876,7 +904,7 @@ mod tests {
 
     #[tokio::test]
     async fn handler_returns_error_for_mismatched_event_payload() {
-        let client = Inngest::new("test-app");
+        let client = Inngest::new("test-app").dev("1");
         let mut handler = Handler::new(&client);
 
         let first_fn: ServableFn<FirstEvent, Error> = client.create_function(
@@ -983,6 +1011,166 @@ mod tests {
         assert!(!payload.url.contains("deployId="));
     }
 
+    #[tokio::test]
+    async fn cloud_mode_requires_primary_signing_key_even_without_signature() {
+        let (handler, fn_id) = registered_handler(Inngest::new("test-app"), None, None);
+        let headers = Headers::from(HeaderMap::new());
+        let body = event_body("test/first", json!({ "message": "hello" }));
+
+        let error = match handler
+            .run(&headers, &RunQueryParams { fn_id }, &body.to_string(), &body)
+            .await
+        {
+            Ok(_) => panic!("cloud mode should reject missing primary signing key"),
+            Err(error) => error,
+        };
+
+        assert_basic_error(
+            error,
+            "no signing key available for verifying request signature",
+        );
+    }
+
+    #[tokio::test]
+    async fn cloud_mode_requires_signature_even_if_request_claims_dev() {
+        let (handler, fn_id) = registered_handler(
+            Inngest::new("test-app"),
+            Some(PRIMARY_SIGNING_KEY),
+            None,
+        );
+        let headers = headers(&[(header::INNGEST_SERVER_KIND, "dev")]);
+        let body = event_body("test/first", json!({ "message": "hello" }));
+
+        let error = match handler
+            .run(&headers, &RunQueryParams { fn_id }, &body.to_string(), &body)
+            .await
+        {
+            Ok(_) => panic!("cloud mode should still require a signature"),
+            Err(error) => error,
+        };
+
+        assert_basic_error(error, "no signature provided for SDK in Cloud mode");
+    }
+
+    #[tokio::test]
+    async fn dev_mode_allows_unsigned_requests_even_if_request_claims_cloud() {
+        let client = Inngest::new("test-app").dev("1");
+        let (handler, fn_id) = registered_handler(client, None, None);
+        let headers = headers(&[(header::INNGEST_SERVER_KIND, "cloud")]);
+        let body = event_body("test/first", json!({ "message": "hello" }));
+
+        let response = handler
+            .run(&headers, &RunQueryParams { fn_id }, &body.to_string(), &body)
+            .await
+            .expect("dev mode should allow unsigned requests");
+
+        assert_eq!(response.status, 200);
+    }
+
+    #[tokio::test]
+    async fn dev_mode_validates_present_signatures_when_primary_key_exists() {
+        let client = Inngest::new("test-app").dev("1");
+        let (handler, fn_id) = registered_handler(client, Some(PRIMARY_SIGNING_KEY), None);
+        let body = event_body("test/first", json!({ "message": "hello" }));
+        let headers = headers(&[(header::INNGEST_SIGNATURE, "t=1&s=deadbeef")]);
+
+        let error = match handler
+            .run(&headers, &RunQueryParams { fn_id }, &body.to_string(), &body)
+            .await
+        {
+            Ok(_) => panic!("invalid signatures should fail in dev mode when a key is configured"),
+            Err(error) => error,
+        };
+
+        assert_basic_error(error, "sig");
+    }
+
+    #[tokio::test]
+    async fn run_uses_fallback_signing_key_when_primary_verification_fails() {
+        let (handler, fn_id) = registered_handler(
+            Inngest::new("test-app"),
+            Some(PRIMARY_SIGNING_KEY),
+            Some(FALLBACK_SIGNING_KEY),
+        );
+        let body = event_body("test/first", json!({ "message": "hello" }));
+        let signature = sign_body(FALLBACK_SIGNING_KEY, &body.to_string());
+        let headers = headers(&[(header::INNGEST_SIGNATURE, &signature)]);
+
+        let response = handler
+            .run(&headers, &RunQueryParams { fn_id }, &body.to_string(), &body)
+            .await
+            .expect("fallback signing key should validate the request");
+
+        assert_eq!(response.status, 200);
+    }
+
+    #[tokio::test]
+    async fn introspection_returns_authenticated_payload_when_signature_is_valid_in_dev_mode() {
+        let client = Inngest::new("test-app")
+            .dev("1")
+            .api_origin("https://api.example.com")
+            .event_api_origin("https://events.example.com")
+            .event_key("evt-test")
+            .env("branch");
+        let (handler, _fn_id) = registered_handler(
+            client,
+            Some(PRIMARY_SIGNING_KEY),
+            Some(FALLBACK_SIGNING_KEY),
+        );
+        let raw_body = "{\"ok\":true}";
+        let signature = sign_body(PRIMARY_SIGNING_KEY, raw_body);
+        let headers = headers(&[(header::INNGEST_SIGNATURE, &signature)]);
+
+        let result = handler
+            .introspect(&headers, "axum", raw_body)
+            .await
+            .expect("introspection should succeed");
+
+        match result {
+            IntrospectResult::Authenticated(result) => {
+                assert!(result.authentication_succeeded);
+                assert_eq!(result.api_origin, "https://api.example.com");
+                assert_eq!(result.event_api_origin, "https://events.example.com");
+                assert_eq!(result.env, Some("branch".to_string()));
+                assert!(result.has_signing_key_fallback);
+                assert_eq!(result.mode, Kind::Dev);
+                assert_eq!(
+                    result.signing_key_hash,
+                    Signature::new(PRIMARY_SIGNING_KEY).hash().ok()
+                );
+                assert_eq!(
+                    result.signing_key_fallback_hash,
+                    Signature::new(FALLBACK_SIGNING_KEY).hash().ok()
+                );
+            }
+            IntrospectResult::Unauthenticated(_) => {
+                panic!("valid signatures should return the authenticated schema")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn introspection_returns_unauthenticated_payload_when_signature_is_invalid() {
+        let client = Inngest::new("test-app").dev("1");
+        let (handler, _fn_id) = registered_handler(client, Some(PRIMARY_SIGNING_KEY), None);
+        let headers = headers(&[(header::INNGEST_SIGNATURE, "t=1&s=deadbeef")]);
+
+        let result = handler
+            .introspect(&headers, "axum", "{\"ok\":true}")
+            .await
+            .expect("introspection should succeed");
+
+        match result {
+            IntrospectResult::Unauthenticated(result) => {
+                assert_eq!(result.authentication_succeeded, Some(false));
+                assert_eq!(result.mode, Kind::Dev);
+            }
+            IntrospectResult::Authenticated(_) => {
+                panic!("invalid signatures should not return the authenticated schema")
+            }
+        }
+    }
+
     fn event_body(name: &str, data: Value) -> Value {
         json!({
             "ctx": { "attempt": 1, "env": "test", "run_id": "run-1" },
@@ -997,5 +1185,70 @@ mod tests {
             "use_api": false,
             "steps": {}
         })
+    }
+
+    fn registered_handler(
+        client: Inngest,
+        signing_key: Option<&str>,
+        signing_key_fallback: Option<&str>,
+    ) -> (Handler, String) {
+        let mut handler = Handler::new(&client);
+        if let Some(key) = signing_key {
+            handler = handler.signing_key(key);
+        }
+        if let Some(key) = signing_key_fallback {
+            handler = handler.signing_key_fallback(key);
+        }
+
+        let first_fn: ServableFn<FirstEvent, Error> = client.create_function(
+            FunctionOpts::new("first"),
+            Trigger::event("test/first"),
+            |input: Input<FirstEvent>, _step| async move {
+                Ok(json!({ "message": input.event.data.message }))
+            },
+        );
+        let fn_id = first_fn.slug();
+        handler.register_fn(first_fn);
+
+        (handler, fn_id)
+    }
+
+    fn headers(entries: &[(&str, &str)]) -> Headers {
+        let mut header_map = HeaderMap::new();
+        for (name, value) in entries {
+            header_map.insert(
+                axum::http::header::HeaderName::from_bytes(name.as_bytes())
+                    .expect("header name should parse"),
+                value.parse().expect("header value should parse"),
+            );
+        }
+
+        Headers::from(header_map)
+    }
+
+    fn assert_basic_error(error: Error, expected_fragment: &str) {
+        match error {
+            Error::Dev(crate::result::DevError::Basic(message)) => {
+                assert!(message.contains(expected_fragment), "{message}");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    fn sign_body(signing_key: &str, body: &str) -> String {
+        type HmacSha256 = Hmac<Sha256>;
+
+        let timestamp = crate::utils::time::now();
+        let normalized_key = signing_key
+            .splitn(3, '-')
+            .nth(2)
+            .expect("signing key should include a signkey-*- prefix");
+        let mut mac =
+            HmacSha256::new_from_slice(normalized_key.as_bytes()).expect("HMAC key should work");
+        mac.update(format!("{body}{timestamp}").as_bytes());
+
+        let sum = mac.finalize();
+        let signature = base16::encode_lower(&sum.into_bytes());
+        format!("t={timestamp}&s={signature}")
     }
 }

--- a/inngest/src/handler.rs
+++ b/inngest/src/handler.rs
@@ -484,7 +484,10 @@ impl Handler {
         framework: &str,
     ) -> Result<SyncResponse, String> {
         let req = self.sync_payload(_headers, framework);
-        let sync_url = format!("{}/fn/register", self.inngest.inngest_api_origin().trim_end_matches('/'));
+        let sync_url = format!(
+            "{}/fn/register",
+            self.inngest.inngest_api_origin().trim_end_matches('/')
+        );
 
         let mut resp = self
             .send_sync_request(&sync_url, &req, query, self.signing_key.as_deref())
@@ -495,12 +498,7 @@ impl Handler {
             && self.signing_key_fallback.is_some()
         {
             resp = self
-                .send_sync_request(
-                    &sync_url,
-                    &req,
-                    query,
-                    self.signing_key_fallback.as_deref(),
-                )
+                .send_sync_request(&sync_url, &req, query, self.signing_key_fallback.as_deref())
                 .await?;
         }
 
@@ -717,21 +715,21 @@ pub struct InngestSyncSuccess {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::function::ServableFn;
     use axum::{
         extract::State,
         http::{HeaderMap, StatusCode, Uri},
         routing::post,
         Router,
     };
-    use crate::function::ServableFn;
     use hmac::{Hmac, Mac};
     use serde::{Deserialize, Serialize};
+    use sha2::Sha256;
     use std::{
         collections::{HashSet, VecDeque},
         net::TcpListener,
         sync::Arc,
     };
-    use sha2::Sha256;
     use tokio::sync::Mutex;
 
     #[derive(Debug, Deserialize, Serialize)]
@@ -1043,7 +1041,12 @@ mod tests {
         let body = event_body("test/first", json!({ "message": "hello" }));
 
         let error = match handler
-            .run(&headers, &RunQueryParams { fn_id }, &body.to_string(), &body)
+            .run(
+                &headers,
+                &RunQueryParams { fn_id },
+                &body.to_string(),
+                &body,
+            )
             .await
         {
             Ok(_) => panic!("cloud mode should reject missing primary signing key"),
@@ -1058,16 +1061,18 @@ mod tests {
 
     #[tokio::test]
     async fn cloud_mode_requires_signature_even_if_request_claims_dev() {
-        let (handler, fn_id) = registered_handler(
-            Inngest::new("test-app"),
-            Some(PRIMARY_SIGNING_KEY),
-            None,
-        );
+        let (handler, fn_id) =
+            registered_handler(Inngest::new("test-app"), Some(PRIMARY_SIGNING_KEY), None);
         let headers = headers(&[(header::INNGEST_SERVER_KIND, "dev")]);
         let body = event_body("test/first", json!({ "message": "hello" }));
 
         let error = match handler
-            .run(&headers, &RunQueryParams { fn_id }, &body.to_string(), &body)
+            .run(
+                &headers,
+                &RunQueryParams { fn_id },
+                &body.to_string(),
+                &body,
+            )
             .await
         {
             Ok(_) => panic!("cloud mode should still require a signature"),
@@ -1085,7 +1090,12 @@ mod tests {
         let body = event_body("test/first", json!({ "message": "hello" }));
 
         let response = handler
-            .run(&headers, &RunQueryParams { fn_id }, &body.to_string(), &body)
+            .run(
+                &headers,
+                &RunQueryParams { fn_id },
+                &body.to_string(),
+                &body,
+            )
             .await
             .expect("dev mode should allow unsigned requests");
 
@@ -1100,7 +1110,12 @@ mod tests {
         let headers = headers(&[(header::INNGEST_SIGNATURE, "t=1&s=deadbeef")]);
 
         let error = match handler
-            .run(&headers, &RunQueryParams { fn_id }, &body.to_string(), &body)
+            .run(
+                &headers,
+                &RunQueryParams { fn_id },
+                &body.to_string(),
+                &body,
+            )
             .await
         {
             Ok(_) => panic!("invalid signatures should fail in dev mode when a key is configured"),
@@ -1122,7 +1137,12 @@ mod tests {
         let headers = headers(&[(header::INNGEST_SIGNATURE, &signature)]);
 
         let response = handler
-            .run(&headers, &RunQueryParams { fn_id }, &body.to_string(), &body)
+            .run(
+                &headers,
+                &RunQueryParams { fn_id },
+                &body.to_string(),
+                &body,
+            )
             .await
             .expect("fallback signing key should validate the request");
 
@@ -1198,7 +1218,8 @@ mod tests {
 
     #[tokio::test]
     async fn sync_uses_configured_api_origin_even_when_request_header_says_dev() {
-        let (origin, records) = spawn_sync_server(vec![(StatusCode::OK, sync_success_body())]).await;
+        let (origin, records) =
+            spawn_sync_server(vec![(StatusCode::OK, sync_success_body())]).await;
         let client = Inngest::new("test-app").api_origin(&origin);
         let (handler, _fn_id) = registered_handler(client, None, None);
         let headers = headers(&[(header::INNGEST_SERVER_KIND, "dev")]);
@@ -1228,13 +1249,14 @@ mod tests {
     #[tokio::test]
     async fn sync_retries_with_fallback_signing_key_and_sets_protocol_headers() {
         let (origin, records) = spawn_sync_server(vec![
-            (StatusCode::UNAUTHORIZED, "{\"error\":\"unauthorized\"}".to_string()),
+            (
+                StatusCode::UNAUTHORIZED,
+                "{\"error\":\"unauthorized\"}".to_string(),
+            ),
             (StatusCode::OK, sync_success_body()),
         ])
         .await;
-        let client = Inngest::new("test-app")
-            .api_origin(&origin)
-            .env("branch");
+        let client = Inngest::new("test-app").api_origin(&origin).env("branch");
         let (handler, _fn_id) = registered_handler(
             client,
             Some(PRIMARY_SIGNING_KEY),

--- a/inngest/src/handler.rs
+++ b/inngest/src/handler.rs
@@ -370,10 +370,9 @@ impl Handler {
         let has_signing_key = self.has_signing_key();
         let has_signing_key_fallback = self.has_signing_key_fallback();
         let schema_version = PROBE_SCHEMA_VERSION.to_string();
-        let authentication_succeeded = match headers.signature() {
-            Some(sig) => Some(self.verify_signature(&sig, raw_body).is_ok()),
-            None => None,
-        };
+        let authentication_succeeded = headers
+            .signature()
+            .map(|sig| self.verify_signature(&sig, raw_body).is_ok());
 
         if authentication_succeeded == Some(true) {
             let api_origin = match self.inngest.api_origin.clone() {
@@ -718,12 +717,22 @@ pub struct InngestSyncSuccess {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::{
+        extract::State,
+        http::{HeaderMap, StatusCode, Uri},
+        routing::post,
+        Router,
+    };
     use crate::function::ServableFn;
-    use axum::http::HeaderMap;
     use hmac::{Hmac, Mac};
     use serde::{Deserialize, Serialize};
-    use std::collections::HashSet;
+    use std::{
+        collections::{HashSet, VecDeque},
+        net::TcpListener,
+        sync::Arc,
+    };
     use sha2::Sha256;
+    use tokio::sync::Mutex;
 
     #[derive(Debug, Deserialize, Serialize)]
     struct FirstEvent {
@@ -739,6 +748,22 @@ mod tests {
         "signkey-test-8ee2262a15e8d3c42d6a840db7af3de2aab08ef632b32a37a687f24b34dba3ff";
     const FALLBACK_SIGNING_KEY: &str =
         "signkey-test-1111111111111111111111111111111111111111111111111111111111111111";
+
+    #[derive(Clone, Debug, Default, PartialEq, Eq)]
+    struct SyncRequestRecord {
+        authorization: Option<String>,
+        env: Option<String>,
+        path: String,
+        query: Option<String>,
+        req_version: Option<String>,
+        sdk: Option<String>,
+    }
+
+    #[derive(Clone)]
+    struct SyncServerState {
+        records: Arc<Mutex<Vec<SyncRequestRecord>>>,
+        responses: Arc<Mutex<VecDeque<(StatusCode, String)>>>,
+    }
 
     #[tokio::test]
     async fn handler_dispatches_functions_with_different_event_types() {
@@ -1171,6 +1196,94 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn sync_uses_configured_api_origin_even_when_request_header_says_dev() {
+        let (origin, records) = spawn_sync_server(vec![(StatusCode::OK, sync_success_body())]).await;
+        let client = Inngest::new("test-app").api_origin(&origin);
+        let (handler, _fn_id) = registered_handler(client, None, None);
+        let headers = headers(&[(header::INNGEST_SERVER_KIND, "dev")]);
+
+        let result = handler
+            .sync(
+                &headers,
+                &SyncQueryParams {
+                    deploy_id: Some("deploy-123".to_string()),
+                },
+                "axum",
+            )
+            .await
+            .expect("sync should use the configured API origin");
+
+        match result {
+            SyncResponse::OutOfBand(result) => assert!(result.modified),
+            SyncResponse::InBand(_) => panic!("sync should use the out-of-band response"),
+        }
+
+        let records = records.lock().await;
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].path, "/fn/register");
+        assert_eq!(records[0].query, Some("deployId=deploy-123".to_string()));
+    }
+
+    #[tokio::test]
+    async fn sync_retries_with_fallback_signing_key_and_sets_protocol_headers() {
+        let (origin, records) = spawn_sync_server(vec![
+            (StatusCode::UNAUTHORIZED, "{\"error\":\"unauthorized\"}".to_string()),
+            (StatusCode::OK, sync_success_body()),
+        ])
+        .await;
+        let client = Inngest::new("test-app")
+            .api_origin(&origin)
+            .env("branch");
+        let (handler, _fn_id) = registered_handler(
+            client,
+            Some(PRIMARY_SIGNING_KEY),
+            Some(FALLBACK_SIGNING_KEY),
+        );
+
+        let result = handler
+            .sync(
+                &Headers::from(HeaderMap::new()),
+                &SyncQueryParams { deploy_id: None },
+                "axum",
+            )
+            .await
+            .expect("sync should retry with the fallback signing key");
+
+        match result {
+            SyncResponse::OutOfBand(result) => assert!(result.modified),
+            SyncResponse::InBand(_) => panic!("sync should use the out-of-band response"),
+        }
+
+        let records = records.lock().await;
+        assert_eq!(records.len(), 2);
+        assert_eq!(
+            records[0].authorization,
+            Some(format!(
+                "Bearer {}",
+                Signature::new(PRIMARY_SIGNING_KEY)
+                    .hash()
+                    .expect("primary signing key should hash"),
+            ))
+        );
+        assert_eq!(
+            records[1].authorization,
+            Some(format!(
+                "Bearer {}",
+                Signature::new(FALLBACK_SIGNING_KEY)
+                    .hash()
+                    .expect("fallback signing key should hash"),
+            ))
+        );
+        assert_eq!(records[0].sdk, Some(crate::version::sdk()));
+        assert_eq!(
+            records[0].req_version,
+            Some(crate::version::EXECUTION_VERSION.to_string())
+        );
+        assert_eq!(records[0].env, Some("branch".to_string()));
+        assert_eq!(records[1].env, Some("branch".to_string()));
+    }
+
     fn event_body(name: &str, data: Value) -> Value {
         json!({
             "ctx": { "attempt": 1, "env": "test", "run_id": "run-1" },
@@ -1250,5 +1363,64 @@ mod tests {
         let sum = mac.finalize();
         let signature = base16::encode_lower(&sum.into_bytes());
         format!("t={timestamp}&s={signature}")
+    }
+
+    async fn spawn_sync_server(
+        responses: Vec<(StatusCode, String)>,
+    ) -> (String, Arc<Mutex<Vec<SyncRequestRecord>>>) {
+        let records = Arc::new(Mutex::new(Vec::new()));
+        let state = SyncServerState {
+            records: Arc::clone(&records),
+            responses: Arc::new(Mutex::new(VecDeque::from(responses))),
+        };
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+        let addr = listener.local_addr().expect("listener addr should exist");
+        let app = Router::new()
+            .route("/fn/register", post(record_sync_request))
+            .with_state(state);
+
+        tokio::spawn(async move {
+            axum::Server::from_tcp(listener)
+                .expect("server should bind")
+                .serve(app.into_make_service())
+                .await
+                .expect("server should serve");
+        });
+
+        (format!("http://{}", addr), records)
+    }
+
+    async fn record_sync_request(
+        State(state): State<SyncServerState>,
+        headers: HeaderMap,
+        uri: Uri,
+    ) -> (StatusCode, String) {
+        state.records.lock().await.push(SyncRequestRecord {
+            authorization: header_value(&headers, "authorization"),
+            env: header_value(&headers, header::INNGEST_ENV),
+            path: uri.path().to_string(),
+            query: uri.query().map(|query| query.to_string()),
+            req_version: header_value(&headers, header::INNGEST_REQ_VERSION),
+            sdk: header_value(&headers, header::INNGEST_SDK),
+        });
+
+        state
+            .responses
+            .lock()
+            .await
+            .pop_front()
+            .unwrap_or((StatusCode::OK, sync_success_body()))
+    }
+
+    fn header_value(headers: &HeaderMap, name: &str) -> Option<String> {
+        headers
+            .get(name)
+            .and_then(|value| value.to_str().ok())
+            .map(|value| value.to_string())
+    }
+
+    fn sync_success_body() -> String {
+        "{\"ok\":true,\"modified\":true}".to_string()
     }
 }

--- a/inngest/src/header.rs
+++ b/inngest/src/header.rs
@@ -9,7 +9,7 @@ pub(crate) const RETRY_AFTER: &str = "retry-after";
 pub(crate) const HOST: &str = "host";
 
 // Inngest specific ones
-// pub(crate) const INNGEST_ENV: &str = "x-inngest-env";
+pub(crate) const INNGEST_ENV: &str = "x-inngest-env";
 // pub(crate) const INNGEST_EXPECTED_SERVER_KIND: &str = "x-inngest-expected-server-kind";
 pub(crate) const INNGEST_FRAMEWORK: &str = "x-inngest-framework";
 pub(crate) const INNGEST_NO_RETRY: &str = "x-inngest-no-retry";


### PR DESCRIPTION
## Summary

This PR implements milestone 001 from the SDK protocol plan and aligns the Rust SDKs mode handling and request authentication behavior with SDK_SPEC.md.

It makes cloud vs dev behavior configuration-driven, adds fallback signing-key support for inbound verification and outbound sync auth, and tightens introspection auth metadata.

## What Changed

- drive cloud/dev mode from SDK configuration instead of X-Inngest-Server-Kind
- require a signing key and request signature for cloud-mode execution requests
- allow unsigned requests in dev mode while still validating provided signatures when a key exists
- support INNGEST_SIGNING_KEY_FALLBACK for inbound verification and sync auth retry on 401
- include required outbound sync auth and protocol headers
- populate authenticated introspection env, fallback presence, and primary/fallback key hashes
- add tests for cloud/dev verification behavior, fallback verification, introspection auth, sync target selection, and outbound fallback auth
- mark plan 001 complete

## Why

The previous implementation mixed request-derived headers into mode selection and did not fully implement the signing-key fallback and introspection requirements from the spec. That made verification behavior nondeterministic and left some cloud/dev cases underspecified.

## Impact

- cloud-mode SDK handlers now reject unsigned or unconfigured requests consistently
- dev-mode handlers remain permissive for unsigned local execution
- sync and authenticated API calls can recover with a fallback signing key when the primary key is invalid
- introspection responses now more accurately report authentication-related state

## Validation

- cargo test -p inngest
- make lint