### PR TITLE
fix(steps): align step identity and memoization behavior

### DIFF
--- a/docs/plans/002-step-identity-and-memoization-correctness.org
+++ b/docs/plans/002-step-identity-and-memoization-correctness.org
@@ -30,15 +30,15 @@
 - [X] Preserve original serialized memoized step errors when surfaced back to Inngest
 - [X] Mark unhandled memoized step errors as non-retriable
 - [ ] Ensure memoized steps are never re-reported
-- [ ] Apply the same memoization decoding rules to inline `steps` payloads and `ctx.use_api` fetched step state
-- [ ] Ensure targeted step execution finds the requested hashed step or returns `StepNotFound`
+- [X] Apply the same memoization decoding rules to inline `steps` payloads and `ctx.use_api` fetched step state
+- [X] Ensure targeted step execution finds the requested hashed step or returns `StepNotFound`
 - [ ] Follow `ctx.stack.stack` ordering when memoizing prior steps
 - [ ] Warn and fall back to earliest-match recovery when stack-ordered memoization cannot be satisfied
 - [X] Add unit tests for step hashing and repeated IDs
 - [X] Add unit tests for memoized success and error decoding
 - [X] Add unit tests for wait-for-event raw payload and `null` timeout decoding
-- [ ] Add unit tests for `ctx.use_api` memoization parity
-- [ ] Add unit tests for targeted `stepId` lookup and `StepNotFound`
+- [X] Add unit tests for `ctx.use_api` memoization parity
+- [X] Add unit tests for targeted `stepId` lookup and `StepNotFound`
 - [ ] Add unit tests for stack-ordered memoization and recovery fallback
 - [ ] Add an e2e test for repeated step IDs replaying with distinct memoized results
 - [ ] Add an e2e test for memoized step-error replay without rerunning the failed step body

--- a/docs/plans/002-step-identity-and-memoization-correctness.org
+++ b/docs/plans/002-step-identity-and-memoization-correctness.org
@@ -11,27 +11,47 @@
 - SHA-1 step hashing
 - Repeated step ID indexing
 - Memoized `{ data }` and `{ error }` handling
-- Deterministic step lookup behavior
+- Wait/sleep and wait-for-event non-wrapped memoization shapes
+- Targeted `stepId` lookup behavior for hashed step execution
+- `ctx.use_api` memoized-step decoding parity
+- Deterministic step lookup behavior, including stack-ordered memoization and recovery
 
 ** Checklist
 - [ ] Fix repeated-step indexing so the first occurrence hashes the bare ID
 - [ ] Ensure repeated occurrences hash `id:1`, `id:2`, and so on
 - [ ] Confirm hash output format stays hex-encoded SHA-1
+- [ ] Count repeated IDs by prior step discovery, not only by prior reporting
 - [ ] Replace the current raw-value memoization assumptions with spec-shaped decoding
 - [ ] Decode memoized run results from `{ data }` or `{ error }`
 - [ ] Decode memoized invoke results from `{ data }` or `{ error }`
 - [ ] Preserve wait/sleep handling for `null` memoized values
+- [ ] Decode successful wait-for-event memoization from the raw event payload shape
 - [ ] Represent memoized step errors in a structured internal type
+- [ ] Preserve original serialized memoized step errors when surfaced back to Inngest
+- [ ] Mark unhandled memoized step errors as non-retriable
 - [ ] Ensure memoized steps are never re-reported
+- [ ] Apply the same memoization decoding rules to inline `steps` payloads and `ctx.use_api` fetched step state
+- [ ] Ensure targeted step execution finds the requested hashed step or returns `StepNotFound`
+- [ ] Follow `ctx.stack.stack` ordering when memoizing prior steps
+- [ ] Warn and fall back to earliest-match recovery when stack-ordered memoization cannot be satisfied
 - [ ] Add unit tests for step hashing and repeated IDs
 - [ ] Add unit tests for memoized success and error decoding
+- [ ] Add unit tests for wait-for-event raw payload and `null` timeout decoding
+- [ ] Add unit tests for `ctx.use_api` memoization parity
+- [ ] Add unit tests for targeted `stepId` lookup and `StepNotFound`
+- [ ] Add unit tests for stack-ordered memoization and recovery fallback
+- [ ] Add an e2e test for repeated step IDs replaying with distinct memoized results
+- [ ] Add an e2e test for memoized step-error replay without rerunning the failed step body
+- [ ] Add an e2e test for invoke failure replay and memoized error surfacing
+- [ ] Add an e2e test for durable multi-event send replay returning all emitted IDs
+- [ ] Add an e2e test for `sleep_until` resume behavior
 
 ** Exit Criteria
 - [ ] Step IDs are stable and spec-correct across repeated executions
-- [ ] Memoized step state is interpreted consistently across supported step types
-- [ ] Tests cover the hashing and memoization invariants
+- [ ] Memoized step state is interpreted consistently across supported step types and sources
+- [ ] Targeted hashed-step execution is deterministic and spec-correct
+- [ ] Tests cover hashing, memoization, targeted lookup, stack-order recovery, and key e2e replay invariants
 
 ** Out of Scope
 - Step planning
 - Parallel execution
-- Stack-based recovery

--- a/docs/plans/002-step-identity-and-memoization-correctness.org
+++ b/docs/plans/002-step-identity-and-memoization-correctness.org
@@ -1,6 +1,6 @@
 #+AUTHOR: Darwin D. Wu
 #+DATE: 2026-04-16
-#+STATUS: Draft
+#+STATUS: In Progress
 
 * Milestone 002: Step Identity and Memoization Correctness
 
@@ -17,26 +17,26 @@
 - Deterministic step lookup behavior, including stack-ordered memoization and recovery
 
 ** Checklist
-- [ ] Fix repeated-step indexing so the first occurrence hashes the bare ID
-- [ ] Ensure repeated occurrences hash `id:1`, `id:2`, and so on
-- [ ] Confirm hash output format stays hex-encoded SHA-1
-- [ ] Count repeated IDs by prior step discovery, not only by prior reporting
-- [ ] Replace the current raw-value memoization assumptions with spec-shaped decoding
-- [ ] Decode memoized run results from `{ data }` or `{ error }`
-- [ ] Decode memoized invoke results from `{ data }` or `{ error }`
-- [ ] Preserve wait/sleep handling for `null` memoized values
-- [ ] Decode successful wait-for-event memoization from the raw event payload shape
-- [ ] Represent memoized step errors in a structured internal type
-- [ ] Preserve original serialized memoized step errors when surfaced back to Inngest
-- [ ] Mark unhandled memoized step errors as non-retriable
+- [X] Fix repeated-step indexing so the first occurrence hashes the bare ID
+- [X] Ensure repeated occurrences hash `id:1`, `id:2`, and so on
+- [X] Confirm hash output format stays hex-encoded SHA-1
+- [X] Count repeated IDs by prior step discovery, not only by prior reporting
+- [X] Replace the current raw-value memoization assumptions with spec-shaped decoding
+- [X] Decode memoized run results from `{ data }` or `{ error }`
+- [X] Decode memoized invoke results from `{ data }` or `{ error }`
+- [X] Preserve wait/sleep handling for `null` memoized values
+- [X] Decode successful wait-for-event memoization from the raw event payload shape
+- [X] Represent memoized step errors in a structured internal type
+- [X] Preserve original serialized memoized step errors when surfaced back to Inngest
+- [X] Mark unhandled memoized step errors as non-retriable
 - [ ] Ensure memoized steps are never re-reported
 - [ ] Apply the same memoization decoding rules to inline `steps` payloads and `ctx.use_api` fetched step state
 - [ ] Ensure targeted step execution finds the requested hashed step or returns `StepNotFound`
 - [ ] Follow `ctx.stack.stack` ordering when memoizing prior steps
 - [ ] Warn and fall back to earliest-match recovery when stack-ordered memoization cannot be satisfied
-- [ ] Add unit tests for step hashing and repeated IDs
-- [ ] Add unit tests for memoized success and error decoding
-- [ ] Add unit tests for wait-for-event raw payload and `null` timeout decoding
+- [X] Add unit tests for step hashing and repeated IDs
+- [X] Add unit tests for memoized success and error decoding
+- [X] Add unit tests for wait-for-event raw payload and `null` timeout decoding
 - [ ] Add unit tests for `ctx.use_api` memoization parity
 - [ ] Add unit tests for targeted `stepId` lookup and `StepNotFound`
 - [ ] Add unit tests for stack-ordered memoization and recovery fallback

--- a/docs/plans/002-step-identity-and-memoization-correctness.org
+++ b/docs/plans/002-step-identity-and-memoization-correctness.org
@@ -1,6 +1,6 @@
 #+AUTHOR: Darwin D. Wu
 #+DATE: 2026-04-16
-#+STATUS: In Progress
+#+STATUS: Done
 
 * Milestone 002: Step Identity and Memoization Correctness
 
@@ -29,7 +29,7 @@
 - [X] Represent memoized step errors in a structured internal type
 - [X] Preserve original serialized memoized step errors when surfaced back to Inngest
 - [X] Mark unhandled memoized step errors as non-retriable
-- [ ] Ensure memoized steps are never re-reported
+- [X] Ensure memoized steps are never re-reported
 - [X] Apply the same memoization decoding rules to inline `steps` payloads and `ctx.use_api` fetched step state
 - [X] Ensure targeted step execution finds the requested hashed step or returns `StepNotFound`
 - [X] Follow `ctx.stack.stack` ordering when memoizing prior steps
@@ -41,16 +41,16 @@
 - [X] Add unit tests for targeted `stepId` lookup and `StepNotFound`
 - [X] Add unit tests for stack-ordered memoization and recovery fallback
 - [X] Add an e2e test for repeated step IDs replaying with distinct memoized results
-- [ ] Add an e2e test for memoized step-error replay without rerunning the failed step body
+- [X] Add an e2e test for memoized step-error replay without rerunning the failed step body
 - [X] Add an e2e test for invoke failure replay and memoized error surfacing
 - [X] Add an e2e test for durable multi-event send replay returning all emitted IDs
 - [X] Add an e2e test for `sleep_until` resume behavior
 
 ** Exit Criteria
-- [ ] Step IDs are stable and spec-correct across repeated executions
-- [ ] Memoized step state is interpreted consistently across supported step types and sources
-- [ ] Targeted hashed-step execution is deterministic and spec-correct
-- [ ] Tests cover hashing, memoization, targeted lookup, stack-order recovery, and key e2e replay invariants
+- [X] Step IDs are stable and spec-correct across repeated executions
+- [X] Memoized step state is interpreted consistently across supported step types and sources
+- [X] Targeted hashed-step execution is deterministic and spec-correct
+- [X] Tests cover hashing, memoization, targeted lookup, stack-order recovery, and key e2e replay invariants
 
 ** Out of Scope
 - Step planning

--- a/docs/plans/002-step-identity-and-memoization-correctness.org
+++ b/docs/plans/002-step-identity-and-memoization-correctness.org
@@ -32,14 +32,14 @@
 - [ ] Ensure memoized steps are never re-reported
 - [X] Apply the same memoization decoding rules to inline `steps` payloads and `ctx.use_api` fetched step state
 - [X] Ensure targeted step execution finds the requested hashed step or returns `StepNotFound`
-- [ ] Follow `ctx.stack.stack` ordering when memoizing prior steps
-- [ ] Warn and fall back to earliest-match recovery when stack-ordered memoization cannot be satisfied
+- [X] Follow `ctx.stack.stack` ordering when memoizing prior steps
+- [X] Warn and fall back to earliest-match recovery when stack-ordered memoization cannot be satisfied
 - [X] Add unit tests for step hashing and repeated IDs
 - [X] Add unit tests for memoized success and error decoding
 - [X] Add unit tests for wait-for-event raw payload and `null` timeout decoding
 - [X] Add unit tests for `ctx.use_api` memoization parity
 - [X] Add unit tests for targeted `stepId` lookup and `StepNotFound`
-- [ ] Add unit tests for stack-ordered memoization and recovery fallback
+- [X] Add unit tests for stack-ordered memoization and recovery fallback
 - [X] Add an e2e test for repeated step IDs replaying with distinct memoized results
 - [ ] Add an e2e test for memoized step-error replay without rerunning the failed step body
 - [X] Add an e2e test for invoke failure replay and memoized error surfacing

--- a/docs/plans/002-step-identity-and-memoization-correctness.org
+++ b/docs/plans/002-step-identity-and-memoization-correctness.org
@@ -40,11 +40,11 @@
 - [X] Add unit tests for `ctx.use_api` memoization parity
 - [X] Add unit tests for targeted `stepId` lookup and `StepNotFound`
 - [ ] Add unit tests for stack-ordered memoization and recovery fallback
-- [ ] Add an e2e test for repeated step IDs replaying with distinct memoized results
+- [X] Add an e2e test for repeated step IDs replaying with distinct memoized results
 - [ ] Add an e2e test for memoized step-error replay without rerunning the failed step body
-- [ ] Add an e2e test for invoke failure replay and memoized error surfacing
-- [ ] Add an e2e test for durable multi-event send replay returning all emitted IDs
-- [ ] Add an e2e test for `sleep_until` resume behavior
+- [X] Add an e2e test for invoke failure replay and memoized error surfacing
+- [X] Add an e2e test for durable multi-event send replay returning all emitted IDs
+- [X] Add an e2e test for `sleep_until` resume behavior
 
 ** Exit Criteria
 - [ ] Step IDs are stable and spec-correct across repeated executions

--- a/inngest/examples/axum/main.rs
+++ b/inngest/examples/axum/main.rs
@@ -255,6 +255,7 @@ fn fallible_step_run(client: &Inngest) -> ServableFn<StepRunEventData, Error> {
                 Err(err) => match err {
                     DevError::NoRetry(_) => println!("No retry"),
                     DevError::RetryAt(_) => println!("Retry after"),
+                    DevError::Step(err) => println!("Step {}", err),
                     DevError::Basic(msg) => println!("Basic {}", msg),
                 },
                 Ok(_) => println!("Success"),

--- a/inngest/src/function.rs
+++ b/inngest/src/function.rs
@@ -44,6 +44,7 @@ impl Default for FunctionOpts {
 }
 
 impl FunctionOpts {
+    /// Creates function options with the provided identifier.
     pub fn new(id: &str) -> Self {
         FunctionOpts {
             id: id.to_string(),
@@ -51,8 +52,15 @@ impl FunctionOpts {
         }
     }
 
+    /// Overrides the display name shown in Inngest.
     pub fn name(mut self, name: &str) -> Self {
         self.name = Some(name.to_string());
+        self
+    }
+
+    /// Overrides the number of retry attempts the executor should schedule.
+    pub fn retries(mut self, retries: u8) -> Self {
+        self.retries = retries;
         self
     }
 }

--- a/inngest/src/handler.rs
+++ b/inngest/src/handler.rs
@@ -21,11 +21,10 @@ use crate::{
     version::{self, EXECUTION_VERSION},
 };
 
-type DynamicFn =
-    dyn Fn(RunQueryParams, Value) -> BoxFuture<'static, Result<SdkResponse, Error>>
-        + Send
-        + Sync
-        + 'static;
+type DynamicFn = dyn Fn(RunQueryParams, Value) -> BoxFuture<'static, Result<SdkResponse, Error>>
+    + Send
+    + Sync
+    + 'static;
 
 struct DynamicServableFn {
     app_id: String,
@@ -626,11 +625,16 @@ impl Handler {
     }
 
     async fn fetch_run_events(&self, run_id: &str) -> Result<Vec<Value>, Error> {
-        self.fetch_run_resource(&format!("/v0/runs/{run_id}/batch")).await
+        self.fetch_run_resource(&format!("/v0/runs/{run_id}/batch"))
+            .await
     }
 
-    async fn fetch_run_actions(&self, run_id: &str) -> Result<HashMap<String, Option<Value>>, Error> {
-        self.fetch_run_resource(&format!("/v0/runs/{run_id}/actions")).await
+    async fn fetch_run_actions(
+        &self,
+        run_id: &str,
+    ) -> Result<HashMap<String, Option<Value>>, Error> {
+        self.fetch_run_resource(&format!("/v0/runs/{run_id}/actions"))
+            .await
     }
 
     async fn fetch_run_resource<T: DeserializeOwned>(&self, path: &str) -> Result<T, Error> {
@@ -1082,12 +1086,7 @@ mod tests {
         let body = event_body("test/first", json!({ "count": 42 }));
 
         let error = match handler
-            .run(
-                &headers,
-                &run_query(first_fn_id),
-                &body.to_string(),
-                &body,
-            )
+            .run(&headers, &run_query(first_fn_id), &body.to_string(), &body)
             .await
         {
             Ok(_) => panic!("mismatched payload should fail"),
@@ -1179,12 +1178,7 @@ mod tests {
         let body = event_body("test/first", json!({ "message": "hello" }));
 
         let error = match handler
-            .run(
-                &headers,
-                &run_query(fn_id),
-                &body.to_string(),
-                &body,
-            )
+            .run(&headers, &run_query(fn_id), &body.to_string(), &body)
             .await
         {
             Ok(_) => panic!("cloud mode should reject missing primary signing key"),
@@ -1205,12 +1199,7 @@ mod tests {
         let body = event_body("test/first", json!({ "message": "hello" }));
 
         let error = match handler
-            .run(
-                &headers,
-                &run_query(fn_id),
-                &body.to_string(),
-                &body,
-            )
+            .run(&headers, &run_query(fn_id), &body.to_string(), &body)
             .await
         {
             Ok(_) => panic!("cloud mode should still require a signature"),
@@ -1228,12 +1217,7 @@ mod tests {
         let body = event_body("test/first", json!({ "message": "hello" }));
 
         let response = handler
-            .run(
-                &headers,
-                &run_query(fn_id),
-                &body.to_string(),
-                &body,
-            )
+            .run(&headers, &run_query(fn_id), &body.to_string(), &body)
             .await
             .expect("dev mode should allow unsigned requests");
 
@@ -1248,12 +1232,7 @@ mod tests {
         let headers = headers(&[(header::INNGEST_SIGNATURE, "t=1&s=deadbeef")]);
 
         let error = match handler
-            .run(
-                &headers,
-                &run_query(fn_id),
-                &body.to_string(),
-                &body,
-            )
+            .run(&headers, &run_query(fn_id), &body.to_string(), &body)
             .await
         {
             Ok(_) => panic!("invalid signatures should fail in dev mode when a key is configured"),
@@ -1275,12 +1254,7 @@ mod tests {
         let headers = headers(&[(header::INNGEST_SIGNATURE, &signature)]);
 
         let response = handler
-            .run(
-                &headers,
-                &run_query(fn_id),
-                &body.to_string(),
-                &body,
-            )
+            .run(&headers, &run_query(fn_id), &body.to_string(), &body)
             .await
             .expect("fallback signing key should validate the request");
 
@@ -1448,13 +1422,14 @@ mod tests {
     async fn handler_passes_requested_step_id_to_function_context() {
         let client = Inngest::new("test-app").dev("1");
         let mut handler = Handler::new(&client);
-        let func: ServableFn<FirstEvent, Error> = client.create_function(
-            FunctionOpts::new("step-id"),
-            Trigger::event("test/first"),
-            |input: Input<FirstEvent>, _step| async move {
-                Ok(json!({ "step_id": input.ctx.step_id }))
-            },
-        );
+        let func: ServableFn<FirstEvent, Error> =
+            client.create_function(
+                FunctionOpts::new("step-id"),
+                Trigger::event("test/first"),
+                |input: Input<FirstEvent>, _step| async move {
+                    Ok(json!({ "step_id": input.ctx.step_id }))
+                },
+            );
         let fn_id = func.slug();
         handler.register_fn(func);
 
@@ -1560,9 +1535,7 @@ mod tests {
     #[tokio::test]
     async fn use_api_requests_fetch_events_and_steps_with_auth_headers() {
         let (origin, records) = spawn_run_api_server().await;
-        let client = Inngest::new("test-app")
-            .dev(&origin)
-            .env("branch");
+        let client = Inngest::new("test-app").dev(&origin).env("branch");
         let mut handler = Handler::new(&client).signing_key(PRIMARY_SIGNING_KEY);
 
         let func: ServableFn<FirstEvent, Error> = client.create_function(

--- a/inngest/src/handler.rs
+++ b/inngest/src/handler.rs
@@ -134,7 +134,12 @@ where
                         },
                     };
 
-                    let step_tool = StepTool::new(client.clone(), &data.steps, &query.step_id);
+                    let step_tool = StepTool::new(
+                        client.clone(),
+                        &data.steps,
+                        &query.step_id,
+                        &data.ctx.stack.stack,
+                    );
 
                     match std::panic::catch_unwind(AssertUnwindSafe(|| {
                         (step_func.as_ref())(input, step_tool.clone())
@@ -150,17 +155,7 @@ where
                                         flow.acknowledge();
                                         match flow.variant {
                                             FlowControlVariant::StepGenerator => {
-                                                let (status, body) = if step_tool.error().is_some() {
-                                                    match serde_json::to_value(step_tool.error()) {
-                                                        Ok(v) => (500, v),
-                                                        Err(err) => {
-                                                            return Err(basic_error!(
-                                                                "error seralizing step error: {}",
-                                                                err
-                                                            ));
-                                                        }
-                                                    }
-                                                } else if let Some(step_id) = step_tool.missing_step()
+                                                let (status, body) = if let Some(step_id) = step_tool.missing_step()
                                                 {
                                                     (
                                                         206,
@@ -749,12 +744,22 @@ struct RunRequestBody<T: 'static> {
 #[derive(Deserialize, Debug)]
 struct RunRequestCtx {
     attempt: u8,
-    // disable_immediate_execution: bool,
+    #[serde(default)]
+    _disable_immediate_execution: bool,
     env: String,
     // fn_id: String,
     run_id: String,
     // step_id: String,
-    // stack: RunRequestCtxStack,
+    #[serde(default)]
+    stack: RunRequestCtxStack,
+}
+
+#[derive(Default, Deserialize, Debug)]
+struct RunRequestCtxStack {
+    #[serde(default, rename = "current")]
+    _current: u32,
+    #[serde(default)]
+    stack: Vec<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]

--- a/inngest/src/handler.rs
+++ b/inngest/src/handler.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, panic::AssertUnwindSafe, sync::Arc};
 
 use futures::{future::BoxFuture, FutureExt};
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha1::Digest;
 use sha2::Sha256;
@@ -22,7 +22,10 @@ use crate::{
 };
 
 type DynamicFn =
-    dyn Fn(String, Value) -> BoxFuture<'static, Result<SdkResponse, Error>> + Send + Sync + 'static;
+    dyn Fn(RunQueryParams, Value) -> BoxFuture<'static, Result<SdkResponse, Error>>
+        + Send
+        + Sync
+        + 'static;
 
 struct DynamicServableFn {
     app_id: String,
@@ -67,8 +70,8 @@ impl DynamicServableFn {
         }
     }
 
-    async fn run(&self, fn_id: String, body: Value) -> Result<SdkResponse, Error> {
-        (self.func)(fn_id, body).await
+    async fn run(&self, query: RunQueryParams, body: Value) -> Result<SdkResponse, Error> {
+        (self.func)(query, body).await
     }
 }
 
@@ -103,7 +106,7 @@ where
             app_id,
             opts,
             trigger,
-            func: Box::new(move |fn_id, body| {
+            func: Box::new(move |query, body| {
                 let step_func = Arc::clone(&func);
                 let client = client.clone();
 
@@ -125,14 +128,14 @@ where
                         events: data.events,
                         ctx: InputCtx {
                             env: data.ctx.env.clone(),
-                            fn_id,
+                            fn_id: query.fn_id.clone(),
                             run_id: data.ctx.run_id.clone(),
-                            step_id: "step".to_string(),
+                            step_id: query.step_id.clone(),
                             attempt: data.ctx.attempt,
                         },
                     };
 
-                    let step_tool = StepTool::new(client.clone(), &data.steps);
+                    let step_tool = StepTool::new(client.clone(), &data.steps, &query.step_id);
 
                     match std::panic::catch_unwind(AssertUnwindSafe(|| {
                         (step_func.as_ref())(input, step_tool.clone())
@@ -158,6 +161,15 @@ where
                                                             ));
                                                         }
                                                     }
+                                                } else if let Some(step_id) = step_tool.missing_step()
+                                                {
+                                                    (
+                                                        206,
+                                                        json!([{
+                                                            "id": step_id,
+                                                            "op": "StepNotFound"
+                                                        }]),
+                                                    )
                                                 } else if !step_tool.genop().is_empty() {
                                                     match serde_json::to_value(step_tool.genop()) {
                                                         Ok(v) => (206, v),
@@ -221,16 +233,22 @@ pub struct Handler {
     mode: Kind,
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct RunQueryParams {
     #[serde(rename = "fnId")]
     fn_id: String,
+    #[serde(default = "default_step_id", rename = "stepId")]
+    step_id: String,
 }
 
 #[derive(Deserialize, Debug)]
 pub struct SyncQueryParams {
     #[serde(rename = "deployId")]
     deploy_id: Option<String>,
+}
+
+fn default_step_id() -> String {
+    "step".to_string()
 }
 
 impl Handler {
@@ -568,9 +586,115 @@ impl Handler {
             ));
         };
 
-        func.run(query.fn_id.clone(), body.clone()).await
+        let hydrated_body = self.hydrate_run_body(body).await?;
+
+        func.run(query.clone(), hydrated_body).await
     }
     // run the function
+
+    async fn hydrate_run_body(&self, body: &Value) -> Result<Value, Error> {
+        if !body
+            .get("use_api")
+            .and_then(Value::as_bool)
+            .unwrap_or_default()
+        {
+            return Ok(body.clone());
+        }
+
+        let run_id = body
+            .get("ctx")
+            .and_then(Value::as_object)
+            .and_then(|ctx| ctx.get("run_id"))
+            .and_then(Value::as_str)
+            .ok_or_else(|| basic_error!("missing run_id for use_api payload hydration"))?;
+
+        let events = self.fetch_run_events(run_id).await?;
+        let event = events
+            .first()
+            .cloned()
+            .ok_or_else(|| basic_error!("fetched batch events were empty for run {}", run_id))?;
+        let steps = self.fetch_run_actions(run_id).await?;
+
+        let mut hydrated = body.clone();
+        hydrated["event"] = event;
+        hydrated["events"] = Value::Array(events);
+        hydrated["steps"] = serde_json::to_value(steps)
+            .map_err(|err| basic_error!("error serializing hydrated steps: {}", err))?;
+        hydrated["use_api"] = json!(false);
+
+        Ok(hydrated)
+    }
+
+    async fn fetch_run_events(&self, run_id: &str) -> Result<Vec<Value>, Error> {
+        self.fetch_run_resource(&format!("/v0/runs/{run_id}/batch")).await
+    }
+
+    async fn fetch_run_actions(&self, run_id: &str) -> Result<HashMap<String, Option<Value>>, Error> {
+        self.fetch_run_resource(&format!("/v0/runs/{run_id}/actions")).await
+    }
+
+    async fn fetch_run_resource<T: DeserializeOwned>(&self, path: &str) -> Result<T, Error> {
+        let mut response = self
+            .send_api_get(path, self.signing_key.as_deref())
+            .await
+            .map_err(|err| basic_error!("{}", err))?;
+
+        if response.status() == reqwest::StatusCode::UNAUTHORIZED
+            && self.signing_key.is_some()
+            && self.signing_key_fallback.is_some()
+        {
+            response = self
+                .send_api_get(path, self.signing_key_fallback.as_deref())
+                .await
+                .map_err(|err| basic_error!("{}", err))?;
+        }
+
+        let status = response.status();
+        if !status.is_success() {
+            return Err(basic_error!(
+                "error fetching run payload from {}: status {}",
+                path,
+                status.as_u16()
+            ));
+        }
+
+        response
+            .json::<T>()
+            .await
+            .map_err(|err| basic_error!("error decoding run payload from {}: {}", path, err))
+    }
+
+    async fn send_api_get(
+        &self,
+        path: &str,
+        auth_key: Option<&str>,
+    ) -> Result<reqwest::Response, String> {
+        let url = format!(
+            "{}{}",
+            self.inngest.inngest_api_origin().trim_end_matches('/'),
+            path
+        );
+        let mut request = reqwest::Client::new()
+            .get(url)
+            .header(header::INNGEST_SDK, version::sdk())
+            .header(header::INNGEST_REQ_VERSION, EXECUTION_VERSION);
+
+        if let Some(env) = self.inngest.env.clone() {
+            request = request.header(header::INNGEST_ENV, env);
+        }
+
+        if let Some(key) = auth_key {
+            let hashed = Signature::new(key)
+                .hash()
+                .map_err(|_| "error hashing signing key".to_string())?;
+            request = request.header("authorization", format!("Bearer {}", hashed));
+        }
+
+        request.send().await.map_err(|err| {
+            println!("ERROR: {:?}", err);
+            format!("error fetching run payload from {}", path)
+        })
+    }
 
     async fn send_sync_request(
         &self,
@@ -719,8 +843,9 @@ mod tests {
     use axum::{
         extract::State,
         http::{HeaderMap, StatusCode, Uri},
-        routing::post,
-        Router,
+        response::IntoResponse,
+        routing::{get, post},
+        Json, Router,
     };
     use hmac::{Hmac, Mac};
     use serde::{Deserialize, Serialize};
@@ -740,6 +865,25 @@ mod tests {
     #[derive(Debug, Deserialize, Serialize)]
     struct SecondEvent {
         count: u32,
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    struct StepTestError {
+        message: String,
+    }
+
+    impl std::fmt::Display for StepTestError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.message)
+        }
+    }
+
+    impl std::error::Error for StepTestError {}
+
+    impl From<StepTestError> for Error {
+        fn from(err: StepTestError) -> Self {
+            Error::Dev(crate::result::DevError::Basic(err.message))
+        }
     }
 
     const PRIMARY_SIGNING_KEY: &str =
@@ -806,7 +950,7 @@ mod tests {
         let first_response = handler
             .run(
                 &headers,
-                &RunQueryParams { fn_id: first_fn_id },
+                &run_query(first_fn_id),
                 &first_body.to_string(),
                 &first_body,
             )
@@ -831,9 +975,7 @@ mod tests {
         let second_response = handler
             .run(
                 &headers,
-                &RunQueryParams {
-                    fn_id: second_fn_id,
-                },
+                &run_query(second_fn_id),
                 &second_body.to_string(),
                 &second_body,
             )
@@ -873,7 +1015,7 @@ mod tests {
         let first_response = handler
             .run(
                 &headers,
-                &RunQueryParams { fn_id: first_fn_id },
+                &run_query(first_fn_id),
                 &event_body("test/first", json!({ "message": "hello" })).to_string(),
                 &event_body("test/first", json!({ "message": "hello" })),
             )
@@ -884,9 +1026,7 @@ mod tests {
         let second_response = handler
             .run(
                 &headers,
-                &RunQueryParams {
-                    fn_id: second_fn_id,
-                },
+                &run_query(second_fn_id),
                 &event_body("test/second", json!({ "count": 42 })).to_string(),
                 &event_body("test/second", json!({ "count": 42 })),
             )
@@ -905,9 +1045,7 @@ mod tests {
         let error = match handler
             .run(
                 &headers,
-                &RunQueryParams {
-                    fn_id: "test-app-missing".to_string(),
-                },
+                &run_query("test-app-missing".to_string()),
                 &body.to_string(),
                 &body,
             )
@@ -946,7 +1084,7 @@ mod tests {
         let error = match handler
             .run(
                 &headers,
-                &RunQueryParams { fn_id: first_fn_id },
+                &run_query(first_fn_id),
                 &body.to_string(),
                 &body,
             )
@@ -1043,7 +1181,7 @@ mod tests {
         let error = match handler
             .run(
                 &headers,
-                &RunQueryParams { fn_id },
+                &run_query(fn_id),
                 &body.to_string(),
                 &body,
             )
@@ -1069,7 +1207,7 @@ mod tests {
         let error = match handler
             .run(
                 &headers,
-                &RunQueryParams { fn_id },
+                &run_query(fn_id),
                 &body.to_string(),
                 &body,
             )
@@ -1092,7 +1230,7 @@ mod tests {
         let response = handler
             .run(
                 &headers,
-                &RunQueryParams { fn_id },
+                &run_query(fn_id),
                 &body.to_string(),
                 &body,
             )
@@ -1112,7 +1250,7 @@ mod tests {
         let error = match handler
             .run(
                 &headers,
-                &RunQueryParams { fn_id },
+                &run_query(fn_id),
                 &body.to_string(),
                 &body,
             )
@@ -1139,7 +1277,7 @@ mod tests {
         let response = handler
             .run(
                 &headers,
-                &RunQueryParams { fn_id },
+                &run_query(fn_id),
                 &body.to_string(),
                 &body,
             )
@@ -1306,6 +1444,202 @@ mod tests {
         assert_eq!(records[1].env, Some("branch".to_string()));
     }
 
+    #[tokio::test]
+    async fn handler_passes_requested_step_id_to_function_context() {
+        let client = Inngest::new("test-app").dev("1");
+        let mut handler = Handler::new(&client);
+        let func: ServableFn<FirstEvent, Error> = client.create_function(
+            FunctionOpts::new("step-id"),
+            Trigger::event("test/first"),
+            |input: Input<FirstEvent>, _step| async move {
+                Ok(json!({ "step_id": input.ctx.step_id }))
+            },
+        );
+        let fn_id = func.slug();
+        handler.register_fn(func);
+
+        let body = event_body("test/first", json!({ "message": "hello" }));
+        let response = handler
+            .run(
+                &Headers::from(HeaderMap::new()),
+                &RunQueryParams {
+                    fn_id,
+                    step_id: "custom-step".to_string(),
+                },
+                &body.to_string(),
+                &body,
+            )
+            .await
+            .expect("handler should pass the requested step id through");
+
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body, json!({ "step_id": "custom-step" }));
+    }
+
+    #[tokio::test]
+    async fn targeted_step_requests_execute_the_matching_hashed_step() {
+        let client = Inngest::new("test-app").dev("1");
+        let mut handler = Handler::new(&client);
+        let func: ServableFn<FirstEvent, Error> = client.create_function(
+            FunctionOpts::new("targeted"),
+            Trigger::event("test/first"),
+            |_input: Input<FirstEvent>, step| async move {
+                let value: Value = step
+                    .run("hello", || async move {
+                        Ok::<_, StepTestError>(json!({ "ok": true }))
+                    })
+                    .await?;
+                Ok(value)
+            },
+        );
+        let fn_id = func.slug();
+        handler.register_fn(func);
+
+        let body = event_body("test/first", json!({ "message": "hello" }));
+        let targeted_step_id = hash_step_id("hello");
+        let response = handler
+            .run(
+                &Headers::from(HeaderMap::new()),
+                &RunQueryParams {
+                    fn_id,
+                    step_id: targeted_step_id.clone(),
+                },
+                &body.to_string(),
+                &body,
+            )
+            .await
+            .expect("matching targeted step should execute");
+
+        assert_eq!(response.status, 206);
+        assert_eq!(response.body[0]["id"], targeted_step_id);
+        assert_eq!(response.body[0]["op"], "StepRun");
+        assert_eq!(response.body[0]["data"], json!({ "ok": true }));
+    }
+
+    #[tokio::test]
+    async fn targeted_step_requests_return_step_not_found_for_other_steps() {
+        let client = Inngest::new("test-app").dev("1");
+        let mut handler = Handler::new(&client);
+        let func: ServableFn<FirstEvent, Error> = client.create_function(
+            FunctionOpts::new("targeted-miss"),
+            Trigger::event("test/first"),
+            |_input: Input<FirstEvent>, step| async move {
+                let _value: Value = step
+                    .run("hello", || async move {
+                        Ok::<_, StepTestError>(json!({ "ok": true }))
+                    })
+                    .await?;
+                Ok(json!({ "unexpected": true }))
+            },
+        );
+        let fn_id = func.slug();
+        handler.register_fn(func);
+
+        let body = event_body("test/first", json!({ "message": "hello" }));
+        let missing_step_id = hash_step_id("other");
+        let response = handler
+            .run(
+                &Headers::from(HeaderMap::new()),
+                &RunQueryParams {
+                    fn_id,
+                    step_id: missing_step_id.clone(),
+                },
+                &body.to_string(),
+                &body,
+            )
+            .await
+            .expect("missing targeted steps should yield step-not-found");
+
+        assert_eq!(response.status, 206);
+        assert_eq!(
+            response.body,
+            json!([{ "id": missing_step_id, "op": "StepNotFound" }])
+        );
+    }
+
+    #[tokio::test]
+    async fn use_api_requests_fetch_events_and_steps_with_auth_headers() {
+        let (origin, records) = spawn_run_api_server().await;
+        let client = Inngest::new("test-app")
+            .dev(&origin)
+            .env("branch");
+        let mut handler = Handler::new(&client).signing_key(PRIMARY_SIGNING_KEY);
+
+        let func: ServableFn<FirstEvent, Error> = client.create_function(
+            FunctionOpts::new("hydrate"),
+            Trigger::event("test/first"),
+            |input: Input<FirstEvent>, step| async move {
+                let memoized: String = step
+                    .run("memoized-step", || async move {
+                        Ok::<_, StepTestError>("rerun".to_string())
+                    })
+                    .await?;
+
+                Ok(json!({
+                    "event_message": input.event.data.message,
+                    "events_len": input.events.len(),
+                    "memoized": memoized,
+                }))
+            },
+        );
+        let fn_id = func.slug();
+        handler.register_fn(func);
+
+        let body = json!({
+            "ctx": { "attempt": 1, "env": "test", "run_id": "run-1" },
+            "event": {
+                "id": null,
+                "name": "test/first",
+                "data": { "message": "placeholder" },
+                "ts": null,
+                "v": null
+            },
+            "events": [],
+            "use_api": true,
+            "steps": {}
+        });
+        let response = handler
+            .run(
+                &Headers::from(HeaderMap::new()),
+                &run_query(fn_id),
+                &body.to_string(),
+                &body,
+            )
+            .await
+            .expect("use_api payloads should hydrate from the API");
+
+        assert_eq!(response.status, 200);
+        assert_eq!(
+            response.body,
+            json!({
+                "event_message": "from-api",
+                "events_len": 2,
+                "memoized": "memoized-from-api",
+            })
+        );
+
+        let records = records.lock().await;
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].path, "/v0/runs/run-1/batch");
+        assert_eq!(records[1].path, "/v0/runs/run-1/actions");
+        assert_eq!(
+            records[0].authorization,
+            Some(format!(
+                "Bearer {}",
+                Signature::new(PRIMARY_SIGNING_KEY)
+                    .hash()
+                    .expect("primary signing key should hash"),
+            ))
+        );
+        assert_eq!(records[0].sdk, Some(crate::version::sdk()));
+        assert_eq!(
+            records[0].req_version,
+            Some(crate::version::EXECUTION_VERSION.to_string())
+        );
+        assert_eq!(records[0].env, Some("branch".to_string()));
+        assert_eq!(records[1].env, Some("branch".to_string()));
+    }
+
     fn event_body(name: &str, data: Value) -> Value {
         json!({
             "ctx": { "attempt": 1, "env": "test", "run_id": "run-1" },
@@ -1320,6 +1654,13 @@ mod tests {
             "use_api": false,
             "steps": {}
         })
+    }
+
+    fn run_query(fn_id: String) -> RunQueryParams {
+        RunQueryParams {
+            fn_id,
+            step_id: default_step_id(),
+        }
     }
 
     fn registered_handler(
@@ -1387,6 +1728,12 @@ mod tests {
         format!("t={timestamp}&s={signature}")
     }
 
+    fn hash_step_id(id: &str) -> String {
+        let mut hasher = sha1::Sha1::new();
+        hasher.update(id.as_bytes());
+        base16::encode_lower(&hasher.finalize())
+    }
+
     async fn spawn_sync_server(
         responses: Vec<(StatusCode, String)>,
     ) -> (String, Arc<Mutex<Vec<SyncRequestRecord>>>) {
@@ -1401,6 +1748,79 @@ mod tests {
         let app = Router::new()
             .route("/fn/register", post(record_sync_request))
             .with_state(state);
+
+        tokio::spawn(async move {
+            axum::Server::from_tcp(listener)
+                .expect("server should bind")
+                .serve(app.into_make_service())
+                .await
+                .expect("server should serve");
+        });
+
+        (format!("http://{}", addr), records)
+    }
+
+    async fn spawn_run_api_server() -> (String, Arc<Mutex<Vec<SyncRequestRecord>>>) {
+        async fn fetch_batch(
+            State(records): State<Arc<Mutex<Vec<SyncRequestRecord>>>>,
+            headers: HeaderMap,
+            uri: Uri,
+        ) -> impl IntoResponse {
+            records.lock().await.push(SyncRequestRecord {
+                authorization: header_value(&headers, "authorization"),
+                env: header_value(&headers, header::INNGEST_ENV),
+                path: uri.path().to_string(),
+                query: uri.query().map(|query| query.to_string()),
+                req_version: header_value(&headers, header::INNGEST_REQ_VERSION),
+                sdk: header_value(&headers, header::INNGEST_SDK),
+            });
+
+            Json(json!([
+                {
+                    "id": "evt-1",
+                    "name": "test/first",
+                    "data": { "message": "from-api" },
+                    "ts": null,
+                    "v": null
+                },
+                {
+                    "id": "evt-2",
+                    "name": "test/first",
+                    "data": { "message": "from-api-2" },
+                    "ts": null,
+                    "v": null
+                }
+            ]))
+        }
+
+        async fn fetch_actions(
+            State(records): State<Arc<Mutex<Vec<SyncRequestRecord>>>>,
+            headers: HeaderMap,
+            uri: Uri,
+        ) -> impl IntoResponse {
+            records.lock().await.push(SyncRequestRecord {
+                authorization: header_value(&headers, "authorization"),
+                env: header_value(&headers, header::INNGEST_ENV),
+                path: uri.path().to_string(),
+                query: uri.query().map(|query| query.to_string()),
+                req_version: header_value(&headers, header::INNGEST_REQ_VERSION),
+                sdk: header_value(&headers, header::INNGEST_SDK),
+            });
+
+            Json(json!({
+                "3ce0995fad5ea2556082d4021be335153233edf9": {
+                    "data": "memoized-from-api"
+                }
+            }))
+        }
+
+        let records = Arc::new(Mutex::new(Vec::new()));
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+        let addr = listener.local_addr().expect("listener addr should exist");
+        let app = Router::new()
+            .route("/v0/runs/run-1/batch", get(fetch_batch))
+            .route("/v0/runs/run-1/actions", get(fetch_actions))
+            .with_state(Arc::clone(&records));
 
         tokio::spawn(async move {
             axum::Server::from_tcp(listener)

--- a/inngest/src/result.rs
+++ b/inngest/src/result.rs
@@ -1,4 +1,5 @@
 use std::{
+    error::Error as StdError,
     fmt::{Debug, Display},
     time::Duration,
 };
@@ -8,7 +9,7 @@ use axum::{
     response::IntoResponse,
     Json,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::{
@@ -27,6 +28,8 @@ pub struct SdkResponse {
 pub enum DevError {
     /// A catch-all error type for business logic errors
     Basic(String),
+    /// A memoized step error surfaced back through replay.
+    Step(StepError),
     /// Error that controls how the function will be retried
     RetryAt(RetryAfterError),
     /// Error that does not allow the function to be retried
@@ -151,6 +154,9 @@ impl IntoResponse for Error {
                     None,
                     StepError::new("Error", msg),
                 ),
+                DevError::Step(err) => {
+                    call_error_response(headers, StatusCode::BAD_REQUEST, true, None, err)
+                }
                 DevError::RetryAt(retry) => {
                     let retry_after = HeaderValue::from(retry.after.as_secs());
 
@@ -223,7 +229,7 @@ fn call_error_response(
 }
 
 /// A serializable error payload returned to Inngest on failed calls.
-#[derive(Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct StepError {
     pub name: String,
     pub message: String,
@@ -235,7 +241,7 @@ pub struct StepError {
 }
 
 impl StepError {
-    fn new(name: impl Into<String>, message: impl Into<String>) -> Self {
+    pub(crate) fn new(name: impl Into<String>, message: impl Into<String>) -> Self {
         Self {
             name: name.into(),
             message: message.into(),
@@ -244,6 +250,14 @@ impl StepError {
         }
     }
 }
+
+impl Display for StepError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.name, self.message)
+    }
+}
+
+impl StdError for StepError {}
 
 /// A retriable developer error that asks Inngest to delay the next attempt.
 pub struct RetryAfterError {
@@ -364,6 +378,33 @@ mod tests {
                 "name": "NonRetryableError",
                 "message": "stop",
                 "stack": "because"
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn memoized_step_errors_return_bad_request_and_preserve_shape() {
+        let response = Error::Dev(DevError::Step(StepError {
+            name: "StepError".to_string(),
+            message: "step failed".to_string(),
+            stack: Some("trace".to_string()),
+            data: Some(json!({ "ignored": true })),
+        }))
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            response.headers().get(header::INNGEST_NO_RETRY).unwrap(),
+            HeaderValue::from_static("true")
+        );
+        assert!(response.headers().get(header::RETRY_AFTER).is_none());
+
+        assert_eq!(
+            response_json(response).await,
+            json!({
+                "name": "StepError",
+                "message": "step failed",
+                "stack": "trace"
             })
         );
     }

--- a/inngest/src/step_tool.rs
+++ b/inngest/src/step_tool.rs
@@ -458,9 +458,8 @@ fn parse_memoized_step_result<T: for<'de> Deserialize<'de>>(
         basic_error!("error parsing memoized {step_kind} result: expected wrapped data or error")
     })?;
 
-    serde_json::from_value::<MemoizedStepResult<T>>(value).map_err(|err| {
-        basic_error!("error deserializing memoized {step_kind} result: {}", err)
-    })
+    serde_json::from_value::<MemoizedStepResult<T>>(value)
+        .map_err(|err| basic_error!("error deserializing memoized {step_kind} result: {}", err))
 }
 
 pub struct WaitForEventOpts {
@@ -698,8 +697,7 @@ mod tests {
     #[test]
     fn wait_for_event_preserves_null_timeout_values() {
         let client = Inngest::new("test-app");
-        let state =
-            HashMap::from([("aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d".to_string(), None)]);
+        let state = HashMap::from([("aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d".to_string(), None)]);
         let step = Step::new(client, &state, "step");
 
         let result = step

--- a/inngest/src/step_tool.rs
+++ b/inngest/src/step_tool.rs
@@ -442,6 +442,7 @@ impl Step {
     }
 }
 
+#[cfg(test)]
 fn parse_invoke_response<T: for<'de> Deserialize<'de>>(value: Value) -> Result<T, Error> {
     match parse_memoized_step_result(Some(value), "invoke step")? {
         MemoizedStepResult::Data { data } => Ok(data),

--- a/inngest/src/step_tool.rs
+++ b/inngest/src/step_tool.rs
@@ -273,7 +273,10 @@ impl Step {
                     name: id.to_string(),
                     display_name: id.to_string(),
                     data: None,
-                    error: Some(step_error_from_user_error::<E>(err.to_string(), serialized_err)),
+                    error: Some(step_error_from_user_error::<E>(
+                        err.to_string(),
+                        serialized_err,
+                    )),
                     opts: json!({}),
                 });
                 Err(Error::Interrupt(FlowControlError::step_generator()))
@@ -681,7 +684,10 @@ mod tests {
             &[first.clone(), second.clone()],
         );
 
-        assert_eq!(state.take_memoized(&first), Some(Some(json!({ "data": "first" }))));
+        assert_eq!(
+            state.take_memoized(&first),
+            Some(Some(json!({ "data": "first" })))
+        );
         assert_eq!(
             state.take_memoized(&second),
             Some(Some(json!({ "data": "second" })))
@@ -703,10 +709,19 @@ mod tests {
             &[first.clone(), second.clone(), third.clone()],
         );
 
-        assert_eq!(state.take_memoized(&second), Some(Some(json!({ "data": "second" }))));
+        assert_eq!(
+            state.take_memoized(&second),
+            Some(Some(json!({ "data": "second" })))
+        );
         assert!(state.recovery_mode());
-        assert_eq!(state.take_memoized(&first), Some(Some(json!({ "data": "first" }))));
-        assert_eq!(state.take_memoized(&third), Some(Some(json!({ "data": "third" }))));
+        assert_eq!(
+            state.take_memoized(&first),
+            Some(Some(json!({ "data": "first" })))
+        );
+        assert_eq!(
+            state.take_memoized(&third),
+            Some(Some(json!({ "data": "third" })))
+        );
     }
 
     #[tokio::test]

--- a/inngest/src/step_tool.rs
+++ b/inngest/src/step_tool.rs
@@ -823,6 +823,7 @@ mod tests {
         let event = result.expect("memoized wait should return an event");
         assert_eq!(event.id.as_deref(), Some("evt-1"));
         assert_eq!(event.data.value, "hello");
+        assert!(step.genop().is_empty());
     }
 
     #[test]
@@ -843,6 +844,7 @@ mod tests {
             .expect("timed out waits should decode to None");
 
         assert!(result.is_none());
+        assert!(step.genop().is_empty());
     }
 
     #[tokio::test]
@@ -894,6 +896,31 @@ mod tests {
 
         assert_eq!(second, vec!["evt-1".to_string()]);
         assert_eq!(server.state.requests.load(Ordering::SeqCst), 1);
+        assert!(memoized_step.genop().is_empty());
+    }
+
+    #[test]
+    fn invoke_reuses_wrapped_memoized_data_without_reporting() {
+        let client = Inngest::new("test-app");
+        let state = HashMap::from([(
+            "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d".to_string(),
+            Some(json!({ "data": "hello" })),
+        )]);
+        let step = Step::new(client, &state, "step", &[]);
+
+        let result = step
+            .invoke::<String>(
+                "hello",
+                InvokeFunctionOpts {
+                    function_id: "child-fn".to_string(),
+                    data: json!({ "value": "ignored" }),
+                    timeout: None,
+                },
+            )
+            .expect("memoized invoke should return stored data");
+
+        assert_eq!(result, "hello".to_string());
+        assert!(step.genop().is_empty());
     }
 
     #[tokio::test]

--- a/inngest/src/step_tool.rs
+++ b/inngest/src/step_tool.rs
@@ -23,6 +23,7 @@ use crate::{
 #[derive(Serialize, Clone)]
 enum Opcode {
     StepRun,
+    StepError,
     Sleep,
     WaitForEvent,
     InvokeFunction,
@@ -36,16 +37,23 @@ pub(crate) struct GeneratorOpCode {
     name: String,
     #[serde(rename(serialize = "displayName"))]
     display_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     data: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<StepError>,
+    #[serde(skip_serializing_if = "is_empty_object")]
     opts: Value,
+}
+
+fn is_empty_object(value: &Value) -> bool {
+    matches!(value, Value::Object(map) if map.is_empty())
 }
 
 mod state {
     use super::{GeneratorOpCode, Op};
-    use crate::result::StepError;
     use serde_json::Value;
     use std::{
-        collections::HashMap,
+        collections::{HashMap, VecDeque},
         sync::{Arc, RwLock},
     };
 
@@ -53,8 +61,9 @@ mod state {
     struct InnerState {
         state: HashMap<String, Option<Value>>,
         indices: HashMap<String, u64>,
+        stack: VecDeque<String>,
+        recovery_mode: bool,
         genop: Vec<GeneratorOpCode>,
-        error: Option<StepError>,
         missing_step: Option<String>,
     }
 
@@ -76,13 +85,14 @@ mod state {
     }
 
     impl State {
-        pub fn new(state: &HashMap<String, Option<Value>>) -> Self {
+        pub fn new(state: &HashMap<String, Option<Value>>, stack: &[String]) -> Self {
             State {
                 inner: Arc::new(RwLock::new(InnerState {
                     state: state.clone(),
                     indices: HashMap::new(),
+                    stack: VecDeque::from(stack.to_vec()),
+                    recovery_mode: false,
                     genop: Vec::new(),
-                    error: None,
                     missing_step: None,
                 })),
             }
@@ -100,14 +110,6 @@ mod state {
             self.inner.read().unwrap().genop.clone()
         }
 
-        pub fn error(&self) -> Option<StepError> {
-            self.inner.read().unwrap().error.clone()
-        }
-
-        pub fn push_error(&self, err: StepError) {
-            self.inner.write().unwrap().error = Some(err);
-        }
-
         pub fn missing_step(&self) -> Option<String> {
             self.inner.read().unwrap().missing_step.clone()
         }
@@ -116,13 +118,50 @@ mod state {
             self.inner.write().unwrap().missing_step = Some(id);
         }
 
-        pub fn remove(&self, key: &str) -> Option<Option<Value>> {
-            self.inner.write().unwrap().state.remove(key)
+        pub fn take_memoized(&self, key: &str) -> Option<Option<Value>> {
+            let mut inner = self.inner.write().unwrap();
+
+            if !inner.state.contains_key(key) {
+                return None;
+            }
+
+            if inner.stack.is_empty() {
+                return inner.state.remove(key);
+            }
+
+            if inner.recovery_mode {
+                remove_first_match(&mut inner.stack, key);
+                return inner.state.remove(key);
+            }
+
+            if inner.stack.front().map(|id| id == key).unwrap_or(false) {
+                inner.stack.pop_front();
+                return inner.state.remove(key);
+            }
+
+            if remove_first_match(&mut inner.stack, key) {
+                inner.recovery_mode = true;
+                eprintln!(
+                    "warning: memoized step order diverged from ctx.stack.stack; entering recovery mode"
+                );
+                return inner.state.remove(key);
+            }
+
+            inner.state.remove(key)
         }
 
-        pub fn get_hashed(&self, key: &str) -> Option<Option<Value>> {
-            self.inner.read().unwrap().state.get(key).cloned()
+        #[cfg(test)]
+        pub fn recovery_mode(&self) -> bool {
+            self.inner.read().unwrap().recovery_mode
         }
+    }
+
+    fn remove_first_match(stack: &mut VecDeque<String>, key: &str) -> bool {
+        let Some(position) = stack.iter().position(|id| id == key) else {
+            return false;
+        };
+        stack.remove(position);
+        true
     }
 }
 
@@ -153,20 +192,17 @@ impl Step {
         client: Inngest,
         state: &HashMap<String, Option<Value>>,
         target_step_id: &str,
+        stack: &[String],
     ) -> Self {
         Step {
             client,
-            state: State::new(state),
+            state: State::new(state, stack),
             target_step_id: target_step_id.to_string(),
         }
     }
 
     fn new_op(&self, id: &str) -> Op {
         self.state.new_op(id)
-    }
-
-    pub(crate) fn error(&self) -> Option<StepError> {
-        self.state.error()
     }
 
     pub(crate) fn genop(&self) -> Vec<GeneratorOpCode> {
@@ -177,24 +213,16 @@ impl Step {
         self.state.missing_step()
     }
 
-    fn remove(&self, key: &str) -> Option<Option<Value>> {
-        self.state.remove(key)
-    }
-
     fn push_op(&self, op: GeneratorOpCode) {
         self.state.push_op(op);
-    }
-
-    fn push_error(&self, err: StepError) {
-        self.state.push_error(err);
     }
 
     fn push_missing_step(&self, id: String) {
         self.state.push_missing_step(id);
     }
 
-    fn get_hashed(&self, key: &str) -> Option<Option<Value>> {
-        self.state.get_hashed(key)
+    fn take_memoized(&self, key: &str) -> Option<Option<Value>> {
+        self.state.take_memoized(key)
     }
 
     pub async fn run<T, E, F>(&self, id: &str, f: impl FnOnce() -> F) -> Result<T, Error>
@@ -206,7 +234,7 @@ impl Step {
         let op = self.new_op(id);
         let hashed = op.hash();
 
-        if let Some(stored_value) = self.remove(&hashed) {
+        if let Some(stored_value) = self.take_memoized(&hashed) {
             return match parse_memoized_step_result(stored_value, "run step")? {
                 MemoizedStepResult::Data { data } => Ok(data),
                 MemoizedStepResult::Error { error } => Err(Error::Dev(DevError::Step(error))),
@@ -230,23 +258,23 @@ impl Step {
                     name: id.to_string(),
                     display_name: id.to_string(),
                     data: serialized.into(),
+                    error: None,
                     opts: json!({}),
                 });
                 Err(Error::Interrupt(FlowControlError::step_generator()))
             }
             Err(err) => {
-                // TODO: need to handle the following errors returned from the user
-                // - retry after error
-                // - non retriable error
-
                 let serialized_err =
                     serde_json::to_value(&err).map_err(|e| basic_error!("{}", e))?;
 
-                self.push_error(StepError {
-                    name: "Step failed".to_string(),
-                    message: err.to_string(),
-                    stack: None,
-                    data: Some(serialized_err),
+                self.push_op(GeneratorOpCode {
+                    op: Opcode::StepError,
+                    id: hashed,
+                    name: id.to_string(),
+                    display_name: id.to_string(),
+                    data: None,
+                    error: Some(step_error_from_user_error::<E>(err.to_string(), serialized_err)),
+                    opts: json!({}),
                 });
                 Err(Error::Interrupt(FlowControlError::step_generator()))
             }
@@ -258,7 +286,7 @@ impl Step {
         let op = self.new_op(id);
         let hashed = op.hash();
 
-        match self.get_hashed(&hashed) {
+        match self.take_memoized(&hashed) {
             // if state already exists, it means we already slept
             Some(_) => Ok(()),
 
@@ -274,6 +302,7 @@ impl Step {
                     name: id.to_string(),
                     display_name: id.to_string(),
                     data: None,
+                    error: None,
                     opts,
                 });
 
@@ -287,7 +316,7 @@ impl Step {
         let op = self.new_op(id);
         let hashed = op.hash();
 
-        match self.get_hashed(&hashed) {
+        match self.take_memoized(&hashed) {
             Some(_) => Ok(()),
 
             None => {
@@ -309,6 +338,7 @@ impl Step {
                     name: id.to_string(),
                     display_name: id.to_string(),
                     data: None,
+                    error: None,
                     opts,
                 });
 
@@ -326,7 +356,7 @@ impl Step {
         let op = self.new_op(id);
         let hashed = op.hash();
 
-        match self.get_hashed(&hashed) {
+        match self.take_memoized(&hashed) {
             Some(evt) => {
                 match evt {
                     None => Ok(None),
@@ -357,6 +387,7 @@ impl Step {
                     name: id.to_string(),
                     display_name: id.to_string(),
                     data: None,
+                    error: None,
                     opts: wait_opts,
                 });
 
@@ -374,7 +405,7 @@ impl Step {
         let op = self.new_op(id);
         let hashed = op.hash();
 
-        match self.get_hashed(&hashed) {
+        match self.take_memoized(&hashed) {
             Some(resp) => match parse_memoized_step_result(resp, "invoke step")? {
                 MemoizedStepResult::Data { data } => Ok(data),
                 MemoizedStepResult::Error { error } => Err(Error::Dev(DevError::Step(error))),
@@ -398,6 +429,7 @@ impl Step {
                     name: id.to_string(),
                     display_name: id.to_string(),
                     data: None,
+                    error: None,
                     opts: invoke_opts,
                 });
 
@@ -460,6 +492,38 @@ fn parse_memoized_step_result<T: for<'de> Deserialize<'de>>(
 
     serde_json::from_value::<MemoizedStepResult<T>>(value)
         .map_err(|err| basic_error!("error deserializing memoized {step_kind} result: {}", err))
+}
+
+fn step_error_from_user_error<E>(message: String, serialized_err: Value) -> StepError {
+    let name = std::any::type_name::<E>()
+        .rsplit("::")
+        .next()
+        .unwrap_or("StepError")
+        .to_string();
+
+    let stack = serialized_err
+        .get("stack")
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+
+    let name = serialized_err
+        .get("name")
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .unwrap_or(name);
+
+    let message = serialized_err
+        .get("message")
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .unwrap_or(message);
+
+    StepError {
+        name,
+        message,
+        stack,
+        data: Some(serialized_err),
+    }
 }
 
 pub struct WaitForEventOpts {
@@ -594,7 +658,7 @@ mod tests {
 
     #[test]
     fn repeated_step_ids_start_without_a_suffix() {
-        let state = state::State::new(&HashMap::new());
+        let state = state::State::new(&HashMap::new(), &[]);
 
         let first = state.new_op("hello");
         let second = state.new_op("hello");
@@ -605,6 +669,46 @@ mod tests {
         assert_eq!(third.hash(), "7db70735b4beeadfd5cccfe4a5eb48b71acfb404");
     }
 
+    #[test]
+    fn take_memoized_prefers_stack_order_without_entering_recovery_mode() {
+        let first = "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d".to_string();
+        let second = "7c211433f02071597741e6ff5a8ea34789abbf43".to_string();
+        let state = state::State::new(
+            &HashMap::from([
+                (first.clone(), Some(json!({ "data": "first" }))),
+                (second.clone(), Some(json!({ "data": "second" }))),
+            ]),
+            &[first.clone(), second.clone()],
+        );
+
+        assert_eq!(state.take_memoized(&first), Some(Some(json!({ "data": "first" }))));
+        assert_eq!(
+            state.take_memoized(&second),
+            Some(Some(json!({ "data": "second" })))
+        );
+        assert!(!state.recovery_mode());
+    }
+
+    #[test]
+    fn take_memoized_enters_recovery_mode_when_stack_order_diverges() {
+        let first = "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d".to_string();
+        let second = "7c211433f02071597741e6ff5a8ea34789abbf43".to_string();
+        let third = "67c31e17d42dbd5f8e805daeba4c39a7fba8a518".to_string();
+        let state = state::State::new(
+            &HashMap::from([
+                (first.clone(), Some(json!({ "data": "first" }))),
+                (second.clone(), Some(json!({ "data": "second" }))),
+                (third.clone(), Some(json!({ "data": "third" }))),
+            ]),
+            &[first.clone(), second.clone(), third.clone()],
+        );
+
+        assert_eq!(state.take_memoized(&second), Some(Some(json!({ "data": "second" }))));
+        assert!(state.recovery_mode());
+        assert_eq!(state.take_memoized(&first), Some(Some(json!({ "data": "first" }))));
+        assert_eq!(state.take_memoized(&third), Some(Some(json!({ "data": "third" }))));
+    }
+
     #[tokio::test]
     async fn run_reuses_wrapped_memoized_data() {
         let client = Inngest::new("test-app");
@@ -612,7 +716,7 @@ mod tests {
             "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d".to_string(),
             Some(json!({ "data": { "value": "hello" } })),
         )]);
-        let step = Step::new(client, &state, "step");
+        let step = Step::new(client, &state, "step", &[]);
 
         let result: TestEventData = step
             .run("hello", || async {
@@ -629,6 +733,7 @@ mod tests {
                 value: "hello".to_string(),
             }
         );
+        assert!(step.genop().is_empty());
     }
 
     #[tokio::test]
@@ -644,7 +749,7 @@ mod tests {
                 }
             })),
         )]);
-        let step = Step::new(client, &state, "step");
+        let step = Step::new(client, &state, "step", &[]);
 
         let result: Result<TestEventData, Error> = step
             .run("hello", || async {
@@ -662,6 +767,32 @@ mod tests {
             }
             other => panic!("expected memoized step error, got {other:?}"),
         }
+        assert!(step.genop().is_empty());
+    }
+
+    #[tokio::test]
+    async fn run_failures_emit_step_error_opcodes() {
+        let client = Inngest::new("test-app");
+        let step = Step::new(client, &HashMap::new(), "step", &[]);
+
+        let result: Result<TestEventData, Error> = step
+            .run("hello", || async {
+                Err::<TestEventData, TestStepFailure>(TestStepFailure {
+                    message: "step exploded".to_string(),
+                })
+            })
+            .await;
+
+        match result {
+            Err(Error::Interrupt(mut flow)) => flow.acknowledge(),
+            other => panic!("expected step interruption, got {other:?}"),
+        }
+
+        let body = serde_json::to_value(step.genop()).expect("step error opcode should serialize");
+        assert_eq!(body[0]["op"], "StepError");
+        assert_eq!(body[0]["id"], "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d");
+        assert_eq!(body[0]["error"]["name"], "TestStepFailure");
+        assert_eq!(body[0]["error"]["message"], "step exploded");
     }
 
     #[test]
@@ -676,7 +807,7 @@ mod tests {
                 "ts": 1
             })),
         )]);
-        let step = Step::new(client, &state, "step");
+        let step = Step::new(client, &state, "step", &[]);
 
         let result = step
             .wait_for_event::<TestEventData>(
@@ -698,7 +829,7 @@ mod tests {
     fn wait_for_event_preserves_null_timeout_values() {
         let client = Inngest::new("test-app");
         let state = HashMap::from([("aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d".to_string(), None)]);
-        let step = Step::new(client, &state, "step");
+        let step = Step::new(client, &state, "step", &[]);
 
         let result = step
             .wait_for_event::<TestEventData>(
@@ -720,7 +851,7 @@ mod tests {
         let client = Inngest::new("test-app")
             .event_api_origin(&server.url)
             .event_key("test-key");
-        let step = Step::new(client.clone(), &HashMap::new(), "step");
+        let step = Step::new(client.clone(), &HashMap::new(), "step", &[]);
 
         let first = step
             .send_event(
@@ -747,7 +878,7 @@ mod tests {
             step.genop()[0].id.clone(),
             Some(json!({ "data": ["evt-1"] })),
         )]);
-        let memoized_step = Step::new(client, &stored, "step");
+        let memoized_step = Step::new(client, &stored, "step", &[]);
         let second = memoized_step
             .send_event(
                 "send-test",
@@ -771,7 +902,7 @@ mod tests {
         let client = Inngest::new("test-app")
             .event_api_origin(&server.url)
             .event_key("test-key");
-        let step = Step::new(client, &HashMap::new(), "step");
+        let step = Step::new(client, &HashMap::new(), "step", &[]);
 
         let result = step
             .send_events(

--- a/inngest/src/step_tool.rs
+++ b/inngest/src/step_tool.rs
@@ -60,11 +60,12 @@ mod state {
     impl InnerState {
         fn new_op(&mut self, id: &str) -> Op {
             let pos = self.indices.entry(id.to_string()).or_insert(0);
-            *pos += 1;
-            Op {
+            let op = Op {
                 id: id.to_string(),
                 pos: *pos,
-            }
+            };
+            *pos += 1;
+            op
         }
     }
 
@@ -122,10 +123,10 @@ pub struct Step {
 }
 
 #[derive(Deserialize)]
-#[serde(rename_all = "snake_case")]
-enum StepRunResult<T, E> {
-    Data(T),
-    Error(E),
+#[serde(untagged)]
+enum MemoizedStepResult<T> {
+    Data { data: T },
+    Error { error: StepError },
 }
 
 pub trait UserProvidedError<'a>: StdError + Serialize + Deserialize<'a> + Into<Error> {}
@@ -181,14 +182,11 @@ impl Step {
         let op = self.new_op(id);
         let hashed = op.hash();
 
-        if let Some(Some(stored_value)) = self.remove(&hashed) {
-            let run_result: StepRunResult<T, E> =
-                serde_json::from_value(stored_value).map_err(|e| basic_error!("{}", e))?;
-
-            match run_result {
-                StepRunResult::Data(data) => return Ok(data),
-                StepRunResult::Error(err) => return Err(err.into()),
-            }
+        if let Some(stored_value) = self.remove(&hashed) {
+            return match parse_memoized_step_result(stored_value, "run step")? {
+                MemoizedStepResult::Data { data } => Ok(data),
+                MemoizedStepResult::Error { error } => Err(Error::Dev(DevError::Step(error))),
+            };
         }
 
         // If we're here, we need to execute the function
@@ -348,9 +346,9 @@ impl Step {
         let hashed = op.hash();
 
         match self.get_hashed(&hashed) {
-            Some(resp) => match resp {
-                None => Err(Error::NoInvokeFunctionResponseError),
-                Some(v) => parse_invoke_response(v),
+            Some(resp) => match parse_memoized_step_result(resp, "invoke step")? {
+                MemoizedStepResult::Data { data } => Ok(data),
+                MemoizedStepResult::Error { error } => Err(Error::Dev(DevError::Step(error))),
             },
 
             None => {
@@ -416,29 +414,23 @@ impl Step {
 }
 
 fn parse_invoke_response<T: for<'de> Deserialize<'de>>(value: Value) -> Result<T, Error> {
-    #[derive(Deserialize)]
-    struct InvokeErrorBody {
-        message: String,
+    match parse_memoized_step_result(Some(value), "invoke step")? {
+        MemoizedStepResult::Data { data } => Ok(data),
+        MemoizedStepResult::Error { error } => Err(Error::Dev(DevError::Step(error))),
     }
+}
 
-    #[derive(Deserialize)]
-    struct InvokeResponse<T> {
-        data: Option<T>,
-        error: Option<InvokeErrorBody>,
-    }
+fn parse_memoized_step_result<T: for<'de> Deserialize<'de>>(
+    value: Option<Value>,
+    step_kind: &str,
+) -> Result<MemoizedStepResult<T>, Error> {
+    let value = value.ok_or_else(|| {
+        basic_error!("error parsing memoized {step_kind} result: expected wrapped data or error")
+    })?;
 
-    let response = serde_json::from_value::<InvokeResponse<T>>(value)
-        .map_err(|err| basic_error!("error deserializing invoke result: {}", err))?;
-
-    if let Some(data) = response.data {
-        return Ok(data);
-    }
-
-    if let Some(err) = response.error {
-        return Err(basic_error!("{}", err.message));
-    }
-
-    Err(basic_error!("error parsing invoke result: unknown shape"))
+    serde_json::from_value::<MemoizedStepResult<T>>(value).map_err(|err| {
+        basic_error!("error deserializing memoized {step_kind} result: {}", err)
+    })
 }
 
 pub struct WaitForEventOpts {
@@ -470,6 +462,7 @@ impl From<DevError> for StepSendEventError {
     fn from(err: DevError) -> Self {
         let message = match err {
             DevError::Basic(message) => message,
+            DevError::Step(err) => err.to_string(),
             DevError::RetryAt(err) => err.to_string(),
             DevError::NoRetry(err) => err.to_string(),
         };
@@ -502,7 +495,7 @@ impl Op {
         hasher.update(key.as_bytes());
         let res = hasher.finalize();
 
-        base16::encode_upper(res.as_slice())
+        base16::encode_lower(res.as_slice())
     }
 }
 
@@ -526,9 +519,28 @@ mod tests {
         bodies: Arc<Mutex<Vec<Value>>>,
     }
 
-    #[derive(Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
     struct TestEventData {
         value: String,
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    struct TestStepFailure {
+        message: String,
+    }
+
+    impl Display for TestStepFailure {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.message)
+        }
+    }
+
+    impl StdError for TestStepFailure {}
+
+    impl From<TestStepFailure> for Error {
+        fn from(err: TestStepFailure) -> Self {
+            Error::Dev(DevError::Basic(err.message))
+        }
     }
 
     #[test]
@@ -538,7 +550,7 @@ mod tests {
             pos: 0,
         };
 
-        assert_eq!(op.hash(), "AAF4C61DDCC5E8A2DABEDE0F3B482CD9AEA9434D");
+        assert_eq!(op.hash(), "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d");
     }
 
     #[test]
@@ -548,7 +560,130 @@ mod tests {
             pos: 1,
         };
 
-        assert_eq!(op.hash(), "20A9BB9477C4AC565CF084D1614C58BBF0A523FF");
+        assert_eq!(op.hash(), "20a9bb9477c4ac565cf084d1614c58bbf0a523ff");
+    }
+
+    #[test]
+    fn repeated_step_ids_start_without_a_suffix() {
+        let state = state::State::new(&HashMap::new());
+
+        let first = state.new_op("hello");
+        let second = state.new_op("hello");
+        let third = state.new_op("hello");
+
+        assert_eq!(first.hash(), "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d");
+        assert_eq!(second.hash(), "20a9bb9477c4ac565cf084d1614c58bbf0a523ff");
+        assert_eq!(third.hash(), "7db70735b4beeadfd5cccfe4a5eb48b71acfb404");
+    }
+
+    #[tokio::test]
+    async fn run_reuses_wrapped_memoized_data() {
+        let client = Inngest::new("test-app");
+        let state = HashMap::from([(
+            "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d".to_string(),
+            Some(json!({ "data": { "value": "hello" } })),
+        )]);
+        let step = Step::new(client, &state);
+
+        let result: TestEventData = step
+            .run("hello", || async {
+                Err::<TestEventData, TestStepFailure>(TestStepFailure {
+                    message: "step should not rerun".to_string(),
+                })
+            })
+            .await
+            .expect("memoized step should return stored data");
+
+        assert_eq!(
+            result,
+            TestEventData {
+                value: "hello".to_string(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn run_surfaces_wrapped_memoized_errors_as_step_errors() {
+        let client = Inngest::new("test-app");
+        let state = HashMap::from([(
+            "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d".to_string(),
+            Some(json!({
+                "error": {
+                    "name": "StepError",
+                    "message": "memoized failure",
+                    "stack": "trace"
+                }
+            })),
+        )]);
+        let step = Step::new(client, &state);
+
+        let result: Result<TestEventData, Error> = step
+            .run("hello", || async {
+                Err::<TestEventData, TestStepFailure>(TestStepFailure {
+                    message: "step should not rerun".to_string(),
+                })
+            })
+            .await;
+
+        match result {
+            Err(Error::Dev(DevError::Step(err))) => {
+                assert_eq!(err.name, "StepError");
+                assert_eq!(err.message, "memoized failure");
+                assert_eq!(err.stack.as_deref(), Some("trace"));
+            }
+            other => panic!("expected memoized step error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn wait_for_event_uses_raw_memoized_event_payload() {
+        let client = Inngest::new("test-app");
+        let state = HashMap::from([(
+            "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d".to_string(),
+            Some(json!({
+                "name": "test/wait",
+                "id": "evt-1",
+                "data": { "value": "hello" },
+                "ts": 1
+            })),
+        )]);
+        let step = Step::new(client, &state);
+
+        let result = step
+            .wait_for_event::<TestEventData>(
+                "hello",
+                WaitForEventOpts {
+                    event: "test/wait".to_string(),
+                    timeout: Duration::from_secs(1),
+                    if_exp: None,
+                },
+            )
+            .expect("memoized wait should deserialize the raw event");
+
+        let event = result.expect("memoized wait should return an event");
+        assert_eq!(event.id.as_deref(), Some("evt-1"));
+        assert_eq!(event.data.value, "hello");
+    }
+
+    #[test]
+    fn wait_for_event_preserves_null_timeout_values() {
+        let client = Inngest::new("test-app");
+        let state =
+            HashMap::from([("aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d".to_string(), None)]);
+        let step = Step::new(client, &state);
+
+        let result = step
+            .wait_for_event::<TestEventData>(
+                "hello",
+                WaitForEventOpts {
+                    event: "test/wait".to_string(),
+                    timeout: Duration::from_secs(1),
+                    if_exp: None,
+                },
+            )
+            .expect("timed out waits should decode to None");
+
+        assert!(result.is_none());
     }
 
     #[tokio::test]
@@ -657,13 +792,17 @@ mod tests {
     fn invoke_response_returns_error_field() {
         let response = parse_invoke_response::<String>(json!({
             "error": {
-                "message": "invoke failed"
+                "name": "StepError",
+                "message": "invoke failed",
+                "stack": "trace"
             }
         }));
 
         match response {
-            Err(Error::Dev(DevError::Basic(message))) => {
-                assert_eq!(message, "invoke failed");
+            Err(Error::Dev(DevError::Step(err))) => {
+                assert_eq!(err.name, "StepError");
+                assert_eq!(err.message, "invoke failed");
+                assert_eq!(err.stack.as_deref(), Some("trace"));
             }
             other => panic!("expected invoke error, got {other:?}"),
         }

--- a/inngest/src/step_tool.rs
+++ b/inngest/src/step_tool.rs
@@ -55,6 +55,7 @@ mod state {
         indices: HashMap<String, u64>,
         genop: Vec<GeneratorOpCode>,
         error: Option<StepError>,
+        missing_step: Option<String>,
     }
 
     impl InnerState {
@@ -82,6 +83,7 @@ mod state {
                     indices: HashMap::new(),
                     genop: Vec::new(),
                     error: None,
+                    missing_step: None,
                 })),
             }
         }
@@ -106,6 +108,14 @@ mod state {
             self.inner.write().unwrap().error = Some(err);
         }
 
+        pub fn missing_step(&self) -> Option<String> {
+            self.inner.read().unwrap().missing_step.clone()
+        }
+
+        pub fn push_missing_step(&self, id: String) {
+            self.inner.write().unwrap().missing_step = Some(id);
+        }
+
         pub fn remove(&self, key: &str) -> Option<Option<Value>> {
             self.inner.write().unwrap().state.remove(key)
         }
@@ -120,6 +130,7 @@ mod state {
 pub struct Step {
     client: Inngest,
     state: state::State,
+    target_step_id: String,
 }
 
 #[derive(Deserialize)]
@@ -138,10 +149,15 @@ impl<E> UserProvidedError<'_> for E where
 
 impl Step {
     /// Creates a step helper for the current function execution.
-    pub(crate) fn new(client: Inngest, state: &HashMap<String, Option<Value>>) -> Self {
+    pub(crate) fn new(
+        client: Inngest,
+        state: &HashMap<String, Option<Value>>,
+        target_step_id: &str,
+    ) -> Self {
         Step {
             client,
             state: State::new(state),
+            target_step_id: target_step_id.to_string(),
         }
     }
 
@@ -157,6 +173,10 @@ impl Step {
         self.state.genop()
     }
 
+    pub(crate) fn missing_step(&self) -> Option<String> {
+        self.state.missing_step()
+    }
+
     fn remove(&self, key: &str) -> Option<Option<Value>> {
         self.state.remove(key)
     }
@@ -167,6 +187,10 @@ impl Step {
 
     fn push_error(&self, err: StepError) {
         self.state.push_error(err);
+    }
+
+    fn push_missing_step(&self, id: String) {
+        self.state.push_missing_step(id);
     }
 
     fn get_hashed(&self, key: &str) -> Option<Option<Value>> {
@@ -187,6 +211,11 @@ impl Step {
                 MemoizedStepResult::Data { data } => Ok(data),
                 MemoizedStepResult::Error { error } => Err(Error::Dev(DevError::Step(error))),
             };
+        }
+
+        if self.target_step_id != "step" && self.target_step_id != hashed {
+            self.push_missing_step(self.target_step_id.clone());
+            return Err(Error::Interrupt(FlowControlError::step_generator()));
         }
 
         // If we're here, we need to execute the function
@@ -583,7 +612,7 @@ mod tests {
             "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d".to_string(),
             Some(json!({ "data": { "value": "hello" } })),
         )]);
-        let step = Step::new(client, &state);
+        let step = Step::new(client, &state, "step");
 
         let result: TestEventData = step
             .run("hello", || async {
@@ -615,7 +644,7 @@ mod tests {
                 }
             })),
         )]);
-        let step = Step::new(client, &state);
+        let step = Step::new(client, &state, "step");
 
         let result: Result<TestEventData, Error> = step
             .run("hello", || async {
@@ -647,7 +676,7 @@ mod tests {
                 "ts": 1
             })),
         )]);
-        let step = Step::new(client, &state);
+        let step = Step::new(client, &state, "step");
 
         let result = step
             .wait_for_event::<TestEventData>(
@@ -670,7 +699,7 @@ mod tests {
         let client = Inngest::new("test-app");
         let state =
             HashMap::from([("aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d".to_string(), None)]);
-        let step = Step::new(client, &state);
+        let step = Step::new(client, &state, "step");
 
         let result = step
             .wait_for_event::<TestEventData>(
@@ -692,7 +721,7 @@ mod tests {
         let client = Inngest::new("test-app")
             .event_api_origin(&server.url)
             .event_key("test-key");
-        let step = Step::new(client.clone(), &HashMap::new());
+        let step = Step::new(client.clone(), &HashMap::new(), "step");
 
         let first = step
             .send_event(
@@ -719,7 +748,7 @@ mod tests {
             step.genop()[0].id.clone(),
             Some(json!({ "data": ["evt-1"] })),
         )]);
-        let memoized_step = Step::new(client, &stored);
+        let memoized_step = Step::new(client, &stored, "step");
         let second = memoized_step
             .send_event(
                 "send-test",
@@ -743,7 +772,7 @@ mod tests {
         let client = Inngest::new("test-app")
             .event_api_origin(&server.url)
             .event_key("test-key");
-        let step = Step::new(client, &HashMap::new());
+        let step = Step::new(client, &HashMap::new(), "step");
 
         let result = step
             .send_events(

--- a/inngest/tests/invoke_e2e.rs
+++ b/inngest/tests/invoke_e2e.rs
@@ -5,13 +5,16 @@ use inngest::{
     client::Inngest,
     event::Event,
     function::{FunctionOpts, Input, ServableFn, Trigger},
-    result::Error,
+    result::{DevError, Error, NonRetryableError},
     step_tool::{InvokeFunctionOpts, Step as StepTool},
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{
-    sync::{Arc, Mutex},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
     time::Duration,
 };
 
@@ -92,4 +95,81 @@ async fn step_invoke_returns_child_output() {
     let result = wait_for_state(&invoke_result, Duration::from_secs(5)).await;
     assert_eq!(result, "hello-from-child");
     assert_eq!(run.output, json!("hello-from-child"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn step_invoke_replays_memoized_child_errors() {
+    let _lock = DevServerLock::acquire();
+    let _dev_server = DevServer::start().await;
+
+    let app_name = e2e_support::unique_name("invoke-error-e2e-app");
+    let parent_event_name = e2e_support::unique_name("test.invoke.error.parent");
+
+    let client = Inngest::new(&app_name).dev(e2e_support::DEV_SERVER_ORIGIN);
+    let parent_run_id = Arc::new(Mutex::new(None::<String>));
+    let invoke_error_state = Arc::new(Mutex::new(None::<String>));
+    let parent_invocations = Arc::new(AtomicUsize::new(0));
+
+    let child_fn: ServableFn<InvokeEventData, Error> = client.create_function(
+        FunctionOpts::new("invoke-child-error-fn").name("Invoke Child Error Fn"),
+        Trigger::event("never"),
+        |_input: Input<InvokeEventData>, _step: StepTool| async move {
+            Err(Error::Dev(DevError::NoRetry(NonRetryableError {
+                message: "child failed".to_string(),
+                cause: Some("boom".to_string()),
+            })))
+        },
+    );
+    let child_fn_id = child_fn.slug();
+
+    let parent_run_state = Arc::clone(&parent_run_id);
+    let invoke_error_capture = Arc::clone(&invoke_error_state);
+    let parent_invocations_capture = Arc::clone(&parent_invocations);
+    let parent_fn: ServableFn<EmptyEventData, Error> = client.create_function(
+        FunctionOpts::new("invoke-parent-error-fn").name("Invoke Parent Error Fn"),
+        Trigger::event(&parent_event_name),
+        move |input: Input<EmptyEventData>, step: StepTool| {
+            let parent_run_state = Arc::clone(&parent_run_state);
+            let invoke_error_capture = Arc::clone(&invoke_error_capture);
+            let parent_invocations_capture = Arc::clone(&parent_invocations_capture);
+            let child_fn_id = child_fn_id.clone();
+
+            async move {
+                parent_invocations_capture.fetch_add(1, Ordering::SeqCst);
+                *parent_run_state.lock().unwrap() = Some(input.ctx.run_id.clone());
+
+                match step.invoke::<String>(
+                    "invoke-child-error",
+                    InvokeFunctionOpts {
+                        function_id: child_fn_id,
+                        data: json!({ "message": "hello-from-child" }),
+                        timeout: None,
+                    },
+                ) {
+                    Ok(result) => Ok(json!(result)),
+                    Err(Error::Dev(DevError::Step(err))) => {
+                        *invoke_error_capture.lock().unwrap() = Some(err.message.clone());
+                        Ok(json!({ "invoke_error": err.message }))
+                    }
+                    Err(err) => Err(err),
+                }
+            }
+        },
+    );
+
+    let app = spawn_app(client.clone(), vec![child_fn.into(), parent_fn.into()]).await;
+    app.sync().await;
+
+    client
+        .send_event(&Event::new(&parent_event_name, EmptyEventData {}))
+        .await
+        .expect("parent error event should send successfully");
+
+    let run_id = wait_for_state(&parent_run_id, Duration::from_secs(5)).await;
+    let run = wait_for_run_status(&run_id, "Completed", Duration::from_secs(20)).await;
+    let invoke_error = wait_for_state(&invoke_error_state, Duration::from_secs(5)).await;
+
+    assert_eq!(parent_invocations.load(Ordering::SeqCst), 2);
+    assert_eq!(invoke_error, "child failed".to_string());
+    assert_eq!(run.output, json!({ "invoke_error": "child failed" }));
 }

--- a/inngest/tests/send_event_e2e.rs
+++ b/inngest/tests/send_event_e2e.rs
@@ -235,7 +235,10 @@ async fn step_send_events_replays_and_returns_all_emitted_ids() {
     loop {
         let received = child_events.lock().unwrap().clone();
         if received.len() == 2 {
-            let ids = received.iter().map(|event| event.id.clone()).collect::<Vec<_>>();
+            let ids = received
+                .iter()
+                .map(|event| event.id.clone())
+                .collect::<Vec<_>>();
             let messages = received
                 .iter()
                 .map(|event| event.message.clone())

--- a/inngest/tests/send_event_e2e.rs
+++ b/inngest/tests/send_event_e2e.rs
@@ -13,7 +13,10 @@ use inngest::{
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{
-    sync::{Arc, Mutex},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
     time::Duration,
 };
 
@@ -126,4 +129,127 @@ async fn step_send_event_triggers_child_function() {
     assert_eq!(received.id, event_ids[0]);
     assert_eq!(received.name, child_event_name);
     assert_eq!(received.message, "hello-from-parent");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn step_send_events_replays_and_returns_all_emitted_ids() {
+    let _lock = DevServerLock::acquire();
+    let _dev_server = DevServer::start().await;
+
+    let app_name = e2e_support::unique_name("send-many-e2e-app");
+    let parent_event_name = e2e_support::unique_name("test.send.many.parent");
+    let child_event_name = e2e_support::unique_name("test.send.many.child");
+
+    let client = Inngest::new(&app_name).dev(e2e_support::DEV_SERVER_ORIGIN);
+    let parent_run_id = Arc::new(Mutex::new(None::<String>));
+    let sent_event_ids = Arc::new(Mutex::new(None::<Vec<String>>));
+    let child_events = Arc::new(Mutex::new(Vec::<ReceivedChildEvent>::new()));
+    let parent_invocations = Arc::new(AtomicUsize::new(0));
+
+    let child_events_state = Arc::clone(&child_events);
+    let child_fn: ServableFn<SendChildEventData, Error> = client.create_function(
+        FunctionOpts::new("send-many-child-fn").name("Send Many Child Fn"),
+        Trigger::event(&child_event_name),
+        move |input: Input<SendChildEventData>, _step: StepTool| {
+            let child_events_state = Arc::clone(&child_events_state);
+
+            async move {
+                child_events_state.lock().unwrap().push(ReceivedChildEvent {
+                    id: input.event.id.unwrap_or_default(),
+                    name: input.event.name,
+                    message: input.event.data.message,
+                });
+
+                Ok(json!("child-complete"))
+            }
+        },
+    );
+
+    let parent_run_state = Arc::clone(&parent_run_id);
+    let sent_event_ids_state = Arc::clone(&sent_event_ids);
+    let parent_invocations_state = Arc::clone(&parent_invocations);
+    let child_event_name_for_parent = child_event_name.clone();
+    let parent_fn: ServableFn<EmptyEventData, Error> = client.create_function(
+        FunctionOpts::new("send-many-parent-fn").name("Send Many Parent Fn"),
+        Trigger::event(&parent_event_name),
+        move |input: Input<EmptyEventData>, step: StepTool| {
+            let parent_run_state = Arc::clone(&parent_run_state);
+            let sent_event_ids_state = Arc::clone(&sent_event_ids_state);
+            let parent_invocations_state = Arc::clone(&parent_invocations_state);
+            let child_event_name = child_event_name_for_parent.clone();
+
+            async move {
+                parent_invocations_state.fetch_add(1, Ordering::SeqCst);
+                *parent_run_state.lock().unwrap() = Some(input.ctx.run_id.clone());
+
+                let ids = step
+                    .send_events(
+                        "send-children",
+                        vec![
+                            Event::new(
+                                &child_event_name,
+                                SendChildEventData {
+                                    message: "hello-from-parent-1".to_string(),
+                                },
+                            ),
+                            Event::new(
+                                &child_event_name,
+                                SendChildEventData {
+                                    message: "hello-from-parent-2".to_string(),
+                                },
+                            ),
+                        ],
+                    )
+                    .await?;
+
+                *sent_event_ids_state.lock().unwrap() = Some(ids.clone());
+
+                Ok(json!({ "event_ids": ids }))
+            }
+        },
+    );
+
+    let app = spawn_app(client.clone(), vec![child_fn.into(), parent_fn.into()]).await;
+    app.sync().await;
+
+    client
+        .send_event(&Event::new(&parent_event_name, EmptyEventData {}))
+        .await
+        .expect("parent multi-send event should send successfully");
+
+    let run_id = wait_for_state(&parent_run_id, Duration::from_secs(5)).await;
+    let run = wait_for_run_status(&run_id, "Completed", Duration::from_secs(10)).await;
+    let event_ids = wait_for_state(&sent_event_ids, Duration::from_secs(5)).await;
+
+    assert_eq!(parent_invocations.load(Ordering::SeqCst), 2);
+    assert_eq!(event_ids.len(), 2);
+    assert_eq!(run.output, json!({ "event_ids": event_ids.clone() }));
+
+    for event_id in &event_ids {
+        let child_runs = wait_for_event_runs(event_id, Duration::from_secs(10)).await;
+        assert!(!child_runs[0].run_id.is_empty());
+        assert_eq!(child_runs[0].status, "Completed");
+    }
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let received = child_events.lock().unwrap().clone();
+        if received.len() == 2 {
+            let ids = received.iter().map(|event| event.id.clone()).collect::<Vec<_>>();
+            let messages = received
+                .iter()
+                .map(|event| event.message.clone())
+                .collect::<Vec<_>>();
+            assert_eq!(ids.len(), 2);
+            assert!(messages.contains(&"hello-from-parent-1".to_string()));
+            assert!(messages.contains(&"hello-from-parent-2".to_string()));
+            break;
+        }
+
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for both child events"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
 }

--- a/inngest/tests/sleep_e2e.rs
+++ b/inngest/tests/sleep_e2e.rs
@@ -15,7 +15,7 @@ use std::{
         atomic::{AtomicUsize, Ordering},
         Arc, Mutex,
     },
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -84,4 +84,69 @@ async fn step_sleep_pauses_and_resumes_the_run() {
     );
     assert_eq!(handler_invocations.load(Ordering::SeqCst), 2);
     assert_eq!(run.output, json!({ "slept": true }));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn step_sleep_until_pauses_and_resumes_the_run() {
+    let _lock = DevServerLock::acquire();
+    let _dev_server = DevServer::start().await;
+
+    let app_name = e2e_support::unique_name("sleep-until-e2e-app");
+    let sleep_event_name = e2e_support::unique_name("test.sleep.until.parent");
+
+    let client = Inngest::new(&app_name).dev(e2e_support::DEV_SERVER_ORIGIN);
+    let run_id_state = Arc::new(Mutex::new(None::<String>));
+    let resumed_at_state = Arc::new(Mutex::new(None::<Instant>));
+    let handler_invocations = Arc::new(AtomicUsize::new(0));
+
+    let run_id_capture = Arc::clone(&run_id_state);
+    let resumed_at_capture = Arc::clone(&resumed_at_state);
+    let handler_invocations_capture = Arc::clone(&handler_invocations);
+    let sleep_fn: ServableFn<EmptyEventData, Error> = client.create_function(
+        FunctionOpts::new("sleep-until-fn").name("Sleep Until Fn"),
+        Trigger::event(&sleep_event_name),
+        move |input: Input<EmptyEventData>, step: StepTool| {
+            let run_id_capture = Arc::clone(&run_id_capture);
+            let resumed_at_capture = Arc::clone(&resumed_at_capture);
+            let handler_invocations_capture = Arc::clone(&handler_invocations_capture);
+
+            async move {
+                handler_invocations_capture.fetch_add(1, Ordering::SeqCst);
+                *run_id_capture.lock().unwrap() = Some(input.ctx.run_id.clone());
+
+                let wake_at_ms = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .expect("clock should be after unix epoch")
+                    .as_millis() as i64
+                    + 1_200;
+                step.sleep_until("pause-until-complete", wake_at_ms)?;
+
+                *resumed_at_capture.lock().unwrap() = Some(Instant::now());
+
+                Ok(json!({ "slept_until": true }))
+            }
+        },
+    );
+
+    let app = spawn_app(client.clone(), vec![sleep_fn.into()]).await;
+    app.sync().await;
+
+    let sent_at = Instant::now();
+    client
+        .send_event(&Event::new(&sleep_event_name, EmptyEventData {}))
+        .await
+        .expect("sleep-until event should send successfully");
+
+    let run_id = wait_for_state(&run_id_state, Duration::from_secs(5)).await;
+    wait_for_run_status(&run_id, "Running", Duration::from_secs(5)).await;
+
+    let run = wait_for_run_status(&run_id, "Completed", Duration::from_secs(10)).await;
+    let resumed_at = wait_for_state(&resumed_at_state, Duration::from_secs(5)).await;
+
+    assert!(
+        resumed_at.duration_since(sent_at) >= Duration::from_secs(1),
+        "sleep_until resumed too quickly"
+    );
+    assert_eq!(handler_invocations.load(Ordering::SeqCst), 2);
+    assert_eq!(run.output, json!({ "slept_until": true }));
 }

--- a/inngest/tests/step_run_e2e.rs
+++ b/inngest/tests/step_run_e2e.rs
@@ -207,3 +207,78 @@ async fn repeated_step_ids_replay_with_distinct_memoized_results() {
     );
     assert_eq!(run.output, json!(["value-1", "value-2"]));
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn memoized_step_errors_replay_without_rerunning_the_failed_step_body() {
+    let _lock = DevServerLock::acquire();
+    let _dev_server = DevServer::start().await;
+
+    let app_name = e2e_support::unique_name("step-run-error-app");
+    let event_name = e2e_support::unique_name("test.step-run.error");
+
+    let client = Inngest::new(&app_name).dev(e2e_support::DEV_SERVER_ORIGIN);
+    let run_id_state = Arc::new(Mutex::new(None::<String>));
+    let step_error_state = Arc::new(Mutex::new(None::<String>));
+    let handler_invocations = Arc::new(AtomicUsize::new(0));
+    let step_invocations = Arc::new(AtomicUsize::new(0));
+
+    let run_id_capture = Arc::clone(&run_id_state);
+    let step_error_capture = Arc::clone(&step_error_state);
+    let handler_invocations_capture = Arc::clone(&handler_invocations);
+    let step_invocations_capture = Arc::clone(&step_invocations);
+    let step_run_fn: ServableFn<EmptyEventData, Error> = client.create_function(
+        FunctionOpts::new("step-run-error-fn")
+            .name("Step Run Error Fn")
+            .retries(0),
+        Trigger::event(&event_name),
+        move |input: Input<EmptyEventData>, step: StepTool| {
+            let run_id_capture = Arc::clone(&run_id_capture);
+            let step_error_capture = Arc::clone(&step_error_capture);
+            let handler_invocations_capture = Arc::clone(&handler_invocations_capture);
+            let step_invocations_capture = Arc::clone(&step_invocations_capture);
+
+            async move {
+                handler_invocations_capture.fetch_add(1, Ordering::SeqCst);
+                *run_id_capture.lock().unwrap() = Some(input.ctx.run_id.clone());
+
+                match step
+                    .run::<MemoizedStepOutput, MemoizedStepFailure, _>("failing-step", || {
+                        let step_invocations_capture = Arc::clone(&step_invocations_capture);
+
+                        async move {
+                            step_invocations_capture.fetch_add(1, Ordering::SeqCst);
+                            Err::<MemoizedStepOutput, MemoizedStepFailure>(MemoizedStepFailure {
+                                message: "step exploded".to_string(),
+                            })
+                        }
+                    })
+                    .await
+                {
+                    Ok(value) => Ok(json!(value)),
+                    Err(Error::Dev(DevError::Step(err))) => {
+                        *step_error_capture.lock().unwrap() = Some(err.message.clone());
+                        Ok(json!({ "step_error": err.message }))
+                    }
+                    Err(err) => Err(err),
+                }
+            }
+        },
+    );
+
+    let app = spawn_app(client.clone(), vec![step_run_fn.into()]).await;
+    app.sync().await;
+
+    client
+        .send_event(&Event::new(&event_name, EmptyEventData {}))
+        .await
+        .expect("step-error event should send successfully");
+
+    let run_id = wait_for_state(&run_id_state, Duration::from_secs(5)).await;
+    let run = wait_for_run_status(&run_id, "Completed", Duration::from_secs(10)).await;
+    let step_error = wait_for_state(&step_error_state, Duration::from_secs(5)).await;
+
+    assert_eq!(handler_invocations.load(Ordering::SeqCst), 2);
+    assert_eq!(step_invocations.load(Ordering::SeqCst), 1);
+    assert_eq!(step_error, "step exploded".to_string());
+    assert_eq!(run.output, json!({ "step_error": "step exploded" }));
+}

--- a/inngest/tests/step_run_e2e.rs
+++ b/inngest/tests/step_run_e2e.rs
@@ -127,3 +127,80 @@ async fn step_run_reuses_the_memoized_result_after_replay() {
     assert_eq!(step_result, expected);
     assert_eq!(run.output, json!(expected));
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn repeated_step_ids_replay_with_distinct_memoized_results() {
+    let _lock = DevServerLock::acquire();
+    let _dev_server = DevServer::start().await;
+
+    let app_name = e2e_support::unique_name("step-run-repeat-app");
+    let event_name = e2e_support::unique_name("test.step-run.repeat");
+
+    let client = Inngest::new(&app_name).dev(e2e_support::DEV_SERVER_ORIGIN);
+    let run_id_state = Arc::new(Mutex::new(None::<String>));
+    let repeated_results_state = Arc::new(Mutex::new(None::<Vec<String>>));
+    let handler_invocations = Arc::new(AtomicUsize::new(0));
+    let step_invocations = Arc::new(AtomicUsize::new(0));
+
+    let run_id_capture = Arc::clone(&run_id_state);
+    let repeated_results_capture = Arc::clone(&repeated_results_state);
+    let handler_invocations_capture = Arc::clone(&handler_invocations);
+    let step_invocations_capture = Arc::clone(&step_invocations);
+    let step_run_fn: ServableFn<EmptyEventData, Error> = client.create_function(
+        FunctionOpts::new("step-run-repeat-fn").name("Step Run Repeat Fn"),
+        Trigger::event(&event_name),
+        move |input: Input<EmptyEventData>, step: StepTool| {
+            let run_id_capture = Arc::clone(&run_id_capture);
+            let repeated_results_capture = Arc::clone(&repeated_results_capture);
+            let handler_invocations_capture = Arc::clone(&handler_invocations_capture);
+            let step_invocations_capture = Arc::clone(&step_invocations_capture);
+
+            async move {
+                handler_invocations_capture.fetch_add(1, Ordering::SeqCst);
+                *run_id_capture.lock().unwrap() = Some(input.ctx.run_id.clone());
+
+                let first: String = step
+                    .run("same-id", || {
+                        let step_invocations_capture = Arc::clone(&step_invocations_capture);
+                        async move {
+                            let call = step_invocations_capture.fetch_add(1, Ordering::SeqCst);
+                            Ok::<_, MemoizedStepFailure>(format!("value-{}", call + 1))
+                        }
+                    })
+                    .await?;
+
+                let second: String = step
+                    .run("same-id", || {
+                        let step_invocations_capture = Arc::clone(&step_invocations_capture);
+                        async move {
+                            let call = step_invocations_capture.fetch_add(1, Ordering::SeqCst);
+                            Ok::<_, MemoizedStepFailure>(format!("value-{}", call + 1))
+                        }
+                    })
+                    .await?;
+
+                let results = vec![first, second];
+                *repeated_results_capture.lock().unwrap() = Some(results.clone());
+
+                Ok(json!(results))
+            }
+        },
+    );
+
+    let app = spawn_app(client.clone(), vec![step_run_fn.into()]).await;
+    app.sync().await;
+
+    client
+        .send_event(&Event::new(&event_name, EmptyEventData {}))
+        .await
+        .expect("repeat-step event should send successfully");
+
+    let run_id = wait_for_state(&run_id_state, Duration::from_secs(5)).await;
+    let run = wait_for_run_status(&run_id, "Completed", Duration::from_secs(10)).await;
+    let repeated_results = wait_for_state(&repeated_results_state, Duration::from_secs(5)).await;
+
+    assert_eq!(handler_invocations.load(Ordering::SeqCst), 3);
+    assert_eq!(step_invocations.load(Ordering::SeqCst), 2);
+    assert_eq!(repeated_results, vec!["value-1".to_string(), "value-2".to_string()]);
+    assert_eq!(run.output, json!(["value-1", "value-2"]));
+}

--- a/inngest/tests/step_run_e2e.rs
+++ b/inngest/tests/step_run_e2e.rs
@@ -201,6 +201,9 @@ async fn repeated_step_ids_replay_with_distinct_memoized_results() {
 
     assert_eq!(handler_invocations.load(Ordering::SeqCst), 3);
     assert_eq!(step_invocations.load(Ordering::SeqCst), 2);
-    assert_eq!(repeated_results, vec!["value-1".to_string(), "value-2".to_string()]);
+    assert_eq!(
+        repeated_results,
+        vec!["value-1".to_string(), "value-2".to_string()]
+    );
     assert_eq!(run.output, json!(["value-1", "value-2"]));
 }


### PR DESCRIPTION
## Summary
- align step hashing and repeated-ID behavior with the SDK spec
- decode memoized step state from spec-shaped `{ data }` and `{ error }` envelopes, including raw wait-for-event payloads, structured step errors, and no re-reporting of memoized steps
- hydrate `use_api` payloads, honor requested hashed `stepId`, and follow `ctx.stack.stack` ordering with recovery fallback when memoized step order diverges
- add replay-focused coverage for repeated step IDs, invoke failure replay, memoized `step.run` error replay, durable multi-send replay, and `sleep_until`; expose `FunctionOpts::retries()` so zero-retry step-error replay can be exercised in e2e

## Validation
- `cargo test -p inngest`
- `make lint`

## Plan
- milestone 002 is complete
- broader step execution state-machine work remains tracked separately in milestone 004
