### PR TITLE
feat(function): implement config surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,9 +24,10 @@ Use standard conventional commit formatting such as `fix(promapi): handle empty 
 
 ## Development Commands
 
-- commit in logical sections whenever possible to make each commit as reviewable by its own as possible
+- commit in small logical sections whenever possible to make each commit as reviewable by its own as possible
 - run `make lint` and tests targeting the changes to confirm expected results and there are no build failures
 - add comments to public structs, traits and functions so it materializes in cargo docs
+- if you're referencing a plan while implementing, update the plan's checklists as you go
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ If there are other frameworks you like to see, feel free to submit an issue, or 
 | `step.wait_for_event` | :white_check_mark: |
 | `step.invoke`         | :white_check_mark: |
 | `step.send_event`     | :white_check_mark: |
-| CancelOn              | :x:                |
-| Failure handler       | :x:                |
+| CancelOn              | :white_check_mark: |
+| Failure handler       | :white_check_mark: |
 | Retry controls        | :white_check_mark: |
 | Middleware            | :x:                |
 | Connect               | :x:                |
@@ -149,3 +149,29 @@ fn step_run_fn(client: &Inngest) -> ServableFn<StepRunEventData, Error> {
 ```
 
 The handler can register functions with different event payload types on the same app. When batching them with `register_fns(...)`, convert each function with `.into()` as shown above.
+
+Function definitions also support sync metadata such as `cancel`, `idempotency`, `batch_events`, `rate_limit`, `debounce`, `priority`, `concurrency`, `throttle`, `singleton`, and `timeouts`.
+
+Failure handlers use a Rust-style `on_failure(...)` method on the returned `ServableFn`:
+
+```rs
+fn hello_with_failure_fn(client: &Inngest) -> ServableFn<HelloEventData, Error> {
+    client
+        .create_function(
+            FunctionOpts::new("hello-func"),
+            Trigger::event("test/hello"),
+            |input: Input<HelloEventData>, _step: StepTool| async move {
+                Ok(json!({ "hello": input.event.data.msg }))
+            },
+        )
+        .on_failure(
+            |input: Input<FunctionFailureEvent<HelloEventData>>, _step: StepTool| async move {
+                Ok(json!({
+                    "failed_run_id": input.event.data.run_id,
+                    "message": input.event.data.error.message,
+                    "original": input.event.data.event.data.msg,
+                }))
+            },
+        )
+}
+```

--- a/docs/plans/004-function-config-surface.org
+++ b/docs/plans/004-function-config-surface.org
@@ -1,7 +1,7 @@
 #+TITLE: Function Config Surface
 #+AUTHOR: Darwin D. Wu
 #+DATE: 2026-04-16
-#+STATUS: Completed
+#+STATUS: Done
 
 * Goal
 - Expand the function definition API and sync serialization to cover the spec-defined function metadata.

--- a/docs/plans/004-function-config-surface.org
+++ b/docs/plans/004-function-config-surface.org
@@ -1,19 +1,21 @@
 #+TITLE: Function Config Surface
 #+AUTHOR: Darwin D. Wu
 #+DATE: 2026-04-16
-#+STATUS: Draft
+#+STATUS: Active
 
 * Goal
 - Expand the function definition API and sync serialization to cover the spec-defined function metadata.
+- Turn the currently minimal `FunctionOpts` surface into an explicit, test-covered sync contract.
 
 * Scope
 - Public option types
 - Sync payload serialization
 - Validation of supported config shapes
-- Failure handler configuration
+- Failure handler (`on_failure`) configuration
+- Documentation of intentionally deferred config features, if any remain unsupported after implementation
 
 * Checklist
-- [ ] Extend `FunctionOpts` to support the next tier of spec-defined fields
+- [ ] Extend `FunctionOpts` to support the next tier of spec-defined fields with public builder-style setters and rustdoc
 - [ ] Add sync serialization for `cancel`
 - [ ] Add sync serialization for `idempotency`
 - [ ] Add sync serialization for `batchEvents`
@@ -24,16 +26,26 @@
 - [ ] Add sync serialization for `throttle`
 - [ ] Add sync serialization for `singleton`
 - [ ] Add sync serialization for `timeouts`
-- [ ] Add public config surface and sync serialization for failure handlers
+- [ ] Add public `on_failure` config surface and sync serialization for failure handlers
 - [ ] Decide and document validation rules for invalid or unsupported combinations
+- [ ] Decide whether invalid configs are rejected eagerly in builders, at registration time, or only during sync serialization
+- [ ] Validate and document `idempotency` overriding `rateLimit`
+- [ ] Validate and document `batchEvents.maxSize` and `batchEvents.timeout` constraints
+- [ ] Validate and document supported `concurrency` forms, including numeric shorthand vs keyed entries and the maximum entry count
+- [ ] Decide and document whether failure handlers intentionally ignore inherited concurrency, singleton, and retry settings from the parent function
 - [ ] Add serialization tests for each new option surface
+- [ ] Add negative tests for invalid config shapes and unsupported combinations
 - [ ] Update examples and README support notes to match the actual implementation
+- [ ] Update feature/support documentation to distinguish implemented config metadata from still-deferred runtime features
 
 * Exit Criteria
 - [ ] Function definitions can express the supported spec-level scheduling and control metadata
 - [ ] The sync payload matches the public API surface
-- [ ] The new config surface is covered by serialization tests
+- [ ] The new config surface is covered by serialization and validation tests
 - [ ] Failure handler configuration is represented consistently in the public API and sync payload
+- [ ] README and examples no longer imply support mismatches for shipped function config metadata
 
 * Out of Scope
 - Middleware hooks, covered by `006`
+- Connect, streaming, and checkpointing, covered by `007`
+- Step-surface gaps such as `race!` or AI/gateway step types, covered by `005`

--- a/docs/plans/004-function-config-surface.org
+++ b/docs/plans/004-function-config-surface.org
@@ -27,14 +27,14 @@
 - [X] Add sync serialization for `singleton`
 - [X] Add sync serialization for `timeouts`
 - [ ] Add public `on_failure` config surface and sync serialization for failure handlers
-- [ ] Decide and document validation rules for invalid or unsupported combinations
-- [ ] Decide whether invalid configs are rejected eagerly in builders, at registration time, or only during sync serialization
-- [ ] Validate and document `idempotency` overriding `rateLimit`
-- [ ] Validate and document `batchEvents.maxSize` and `batchEvents.timeout` constraints
-- [ ] Validate and document supported `concurrency` forms, including numeric shorthand vs keyed entries and the maximum entry count
+- [X] Decide and document validation rules for invalid or unsupported combinations
+- [X] Decide whether invalid configs are rejected eagerly in builders, at registration time, or only during sync serialization
+- [X] Validate and document `idempotency` overriding `rateLimit`
+- [X] Validate and document `batchEvents.maxSize` and `batchEvents.timeout` constraints
+- [X] Validate and document supported `concurrency` forms, including numeric shorthand vs keyed entries and the maximum entry count
 - [ ] Decide and document whether failure handlers intentionally ignore inherited concurrency, singleton, and retry settings from the parent function
 - [X] Add serialization tests for each new option surface
-- [ ] Add negative tests for invalid config shapes and unsupported combinations
+- [X] Add negative tests for invalid config shapes and unsupported combinations
 - [ ] Update examples and README support notes to match the actual implementation
 - [ ] Update feature/support documentation to distinguish implemented config metadata from still-deferred runtime features
 

--- a/docs/plans/004-function-config-surface.org
+++ b/docs/plans/004-function-config-surface.org
@@ -1,7 +1,7 @@
 #+TITLE: Function Config Surface
 #+AUTHOR: Darwin D. Wu
 #+DATE: 2026-04-16
-#+STATUS: Active
+#+STATUS: Completed
 
 * Goal
 - Expand the function definition API and sync serialization to cover the spec-defined function metadata.
@@ -26,24 +26,24 @@
 - [X] Add sync serialization for `throttle`
 - [X] Add sync serialization for `singleton`
 - [X] Add sync serialization for `timeouts`
-- [ ] Add public `on_failure` config surface and sync serialization for failure handlers
+- [X] Add public `on_failure` config surface and sync serialization for failure handlers
 - [X] Decide and document validation rules for invalid or unsupported combinations
 - [X] Decide whether invalid configs are rejected eagerly in builders, at registration time, or only during sync serialization
 - [X] Validate and document `idempotency` overriding `rateLimit`
 - [X] Validate and document `batchEvents.maxSize` and `batchEvents.timeout` constraints
 - [X] Validate and document supported `concurrency` forms, including numeric shorthand vs keyed entries and the maximum entry count
-- [ ] Decide and document whether failure handlers intentionally ignore inherited concurrency, singleton, and retry settings from the parent function
+- [X] Decide and document whether failure handlers intentionally ignore inherited concurrency, singleton, and retry settings from the parent function
 - [X] Add serialization tests for each new option surface
 - [X] Add negative tests for invalid config shapes and unsupported combinations
-- [ ] Update examples and README support notes to match the actual implementation
-- [ ] Update feature/support documentation to distinguish implemented config metadata from still-deferred runtime features
+- [X] Update examples and README support notes to match the actual implementation
+- [X] Update feature/support documentation to distinguish implemented config metadata from still-deferred runtime features
 
 * Exit Criteria
-- [ ] Function definitions can express the supported spec-level scheduling and control metadata
-- [ ] The sync payload matches the public API surface
-- [ ] The new config surface is covered by serialization and validation tests
-- [ ] Failure handler configuration is represented consistently in the public API and sync payload
-- [ ] README and examples no longer imply support mismatches for shipped function config metadata
+- [X] Function definitions can express the supported spec-level scheduling and control metadata
+- [X] The sync payload matches the public API surface
+- [X] The new config surface is covered by serialization and validation tests
+- [X] Failure handler configuration is represented consistently in the public API and sync payload
+- [X] README and examples no longer imply support mismatches for shipped function config metadata
 
 * Out of Scope
 - Middleware hooks, covered by `006`

--- a/docs/plans/004-function-config-surface.org
+++ b/docs/plans/004-function-config-surface.org
@@ -15,17 +15,17 @@
 - Documentation of intentionally deferred config features, if any remain unsupported after implementation
 
 * Checklist
-- [ ] Extend `FunctionOpts` to support the next tier of spec-defined fields with public builder-style setters and rustdoc
-- [ ] Add sync serialization for `cancel`
-- [ ] Add sync serialization for `idempotency`
-- [ ] Add sync serialization for `batchEvents`
-- [ ] Add sync serialization for `rateLimit`
-- [ ] Add sync serialization for `debounce`
-- [ ] Add sync serialization for `priority`
-- [ ] Add sync serialization for `concurrency`
-- [ ] Add sync serialization for `throttle`
-- [ ] Add sync serialization for `singleton`
-- [ ] Add sync serialization for `timeouts`
+- [X] Extend `FunctionOpts` to support the next tier of spec-defined fields with public builder-style setters and rustdoc
+- [X] Add sync serialization for `cancel`
+- [X] Add sync serialization for `idempotency`
+- [X] Add sync serialization for `batchEvents`
+- [X] Add sync serialization for `rateLimit`
+- [X] Add sync serialization for `debounce`
+- [X] Add sync serialization for `priority`
+- [X] Add sync serialization for `concurrency`
+- [X] Add sync serialization for `throttle`
+- [X] Add sync serialization for `singleton`
+- [X] Add sync serialization for `timeouts`
 - [ ] Add public `on_failure` config surface and sync serialization for failure handlers
 - [ ] Decide and document validation rules for invalid or unsupported combinations
 - [ ] Decide whether invalid configs are rejected eagerly in builders, at registration time, or only during sync serialization
@@ -33,7 +33,7 @@
 - [ ] Validate and document `batchEvents.maxSize` and `batchEvents.timeout` constraints
 - [ ] Validate and document supported `concurrency` forms, including numeric shorthand vs keyed entries and the maximum entry count
 - [ ] Decide and document whether failure handlers intentionally ignore inherited concurrency, singleton, and retry settings from the parent function
-- [ ] Add serialization tests for each new option surface
+- [X] Add serialization tests for each new option surface
 - [ ] Add negative tests for invalid config shapes and unsupported combinations
 - [ ] Update examples and README support notes to match the actual implementation
 - [ ] Update feature/support documentation to distinguish implemented config metadata from still-deferred runtime features

--- a/inngest/src/client.rs
+++ b/inngest/src/client.rs
@@ -113,6 +113,7 @@ impl Inngest {
             opts,
             trigger,
             func: Box::new(move |input, step| func(input, step).boxed()),
+            on_failure: None,
         }
     }
 

--- a/inngest/src/function.rs
+++ b/inngest/src/function.rs
@@ -31,11 +31,21 @@ pub struct InputCtx {
 ///
 /// Durations are serialized as Inngest time strings such as `5m` or `30s`.
 /// Raw strings can be used when the spec accepts an expression or ISO 8601
-/// timestamp.
+/// timestamp. Empty string values are rejected when building the sync payload.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FunctionTime {
     Duration(Duration),
     String(String),
+}
+
+impl FunctionTime {
+    fn validate(&self, field: &str) -> Result<(), String> {
+        if matches!(self, Self::String(value) if value.trim().is_empty()) {
+            return Err(format!("{field} cannot be empty"));
+        }
+
+        Ok(())
+    }
 }
 
 impl From<Duration> for FunctionTime {
@@ -118,6 +128,10 @@ impl FunctionCancel {
 }
 
 /// Configures event batching for a function trigger.
+///
+/// Supported sync payloads require `max_size` to be between `1` and `100`.
+/// Duration-based timeouts are validated to the spec's `1s` to `60s` range
+/// when the sync payload is built.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct FunctionBatchEvents {
     #[serde(rename = "maxSize")]
@@ -274,6 +288,9 @@ impl FunctionConcurrencyOption {
 }
 
 /// Configures how function executions are concurrency-limited.
+///
+/// Keyed concurrency supports at most two options and is validated when the
+/// sync payload is built.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum FunctionConcurrency {
@@ -450,6 +467,9 @@ impl FunctionOpts {
     }
 
     /// Sets an idempotency expression for the function.
+    ///
+    /// When present, the sync payload omits `rate_limit` to match the spec's
+    /// idempotency precedence rules.
     pub fn idempotency(mut self, idempotency: &str) -> Self {
         self.idempotency = Some(idempotency.to_string());
         self
@@ -613,6 +633,90 @@ pub struct Function {
     pub singleton: Option<FunctionSingleton>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeouts: Option<FunctionTimeouts>,
+}
+
+impl Function {
+    /// Validates supported function config shapes during sync payload
+    /// construction.
+    pub fn validate(&self) -> Result<(), String> {
+        if let Some(batch_events) = &self.batch_events {
+            if batch_events.max_size == 0 || batch_events.max_size > 100 {
+                return Err(format!(
+                    "function {} batchEvents.maxSize must be between 1 and 100",
+                    self.id
+                ));
+            }
+
+            batch_events
+                .timeout
+                .validate(&format!("function {} batchEvents.timeout", self.id))?;
+
+            if let FunctionTime::Duration(timeout) = &batch_events.timeout {
+                if *timeout < Duration::from_secs(1) || *timeout > Duration::from_secs(60) {
+                    return Err(format!(
+                        "function {} batchEvents.timeout must be between 1s and 60s",
+                        self.id
+                    ));
+                }
+            }
+        }
+
+        if let Some(FunctionConcurrency::Keyed(options)) = &self.concurrency {
+            if options.is_empty() {
+                return Err(format!(
+                    "function {} concurrency must include at least one keyed option",
+                    self.id
+                ));
+            }
+
+            if options.len() > 2 {
+                return Err(format!(
+                    "function {} concurrency supports at most two keyed options",
+                    self.id
+                ));
+            }
+        }
+
+        for cancel in &self.cancel {
+            if let Some(timeout) = &cancel.timeout {
+                timeout.validate(&format!("function {} cancel.timeout", self.id))?;
+            }
+        }
+
+        if let Some(rate_limit) = &self.rate_limit {
+            rate_limit
+                .period
+                .validate(&format!("function {} rateLimit.period", self.id))?;
+        }
+
+        if let Some(debounce) = &self.debounce {
+            debounce
+                .period
+                .validate(&format!("function {} debounce.period", self.id))?;
+
+            if let Some(timeout) = &debounce.timeout {
+                timeout.validate(&format!("function {} debounce.timeout", self.id))?;
+            }
+        }
+
+        if let Some(throttle) = &self.throttle {
+            throttle
+                .period
+                .validate(&format!("function {} throttle.period", self.id))?;
+        }
+
+        if let Some(timeouts) = &self.timeouts {
+            if let Some(start) = &timeouts.start {
+                start.validate(&format!("function {} timeouts.start", self.id))?;
+            }
+
+            if let Some(finish) = &timeouts.finish {
+                finish.validate(&format!("function {} timeouts.finish", self.id))?;
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/inngest/src/function.rs
+++ b/inngest/src/function.rs
@@ -2,12 +2,13 @@ use crate::{
     client::Inngest,
     event::{Event, InngestEvent},
     step_tool::Step as StepTool,
+    utils::duration,
 };
 use futures::future::BoxFuture;
-use serde::{Deserialize, Serialize};
+use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use slug::slugify;
-use std::{collections::HashMap, fmt::Debug};
+use std::{collections::HashMap, fmt::Debug, time::Duration};
 
 // NOTE: should T have Copy trait too?
 // so it can do something like `input.event` without moving.
@@ -26,11 +27,379 @@ pub struct InputCtx {
     pub attempt: u8,
 }
 
+/// A function-config time value accepted by the sync payload.
+///
+/// Durations are serialized as Inngest time strings such as `5m` or `30s`.
+/// Raw strings can be used when the spec accepts an expression or ISO 8601
+/// timestamp.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FunctionTime {
+    Duration(Duration),
+    String(String),
+}
+
+impl From<Duration> for FunctionTime {
+    fn from(value: Duration) -> Self {
+        Self::Duration(value)
+    }
+}
+
+impl From<String> for FunctionTime {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<&str> for FunctionTime {
+    fn from(value: &str) -> Self {
+        Self::String(value.to_string())
+    }
+}
+
+impl Serialize for FunctionTime {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = match self {
+            Self::Duration(duration) => duration::to_string(*duration),
+            Self::String(value) => value.clone(),
+        };
+
+        serializer.serialize_str(&value)
+    }
+}
+
+impl<'de> Deserialize<'de> for FunctionTime {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        if value.is_empty() {
+            return Err(D::Error::custom("function time values cannot be empty"));
+        }
+
+        Ok(Self::String(value))
+    }
+}
+
+/// Cancels a function run when a matching event is received.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct FunctionCancel {
+    pub event: String,
+    #[serde(rename = "if", skip_serializing_if = "Option::is_none")]
+    pub if_exp: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout: Option<FunctionTime>,
+}
+
+impl FunctionCancel {
+    /// Creates a cancellation rule for the given event name.
+    pub fn new(event: &str) -> Self {
+        Self {
+            event: event.to_string(),
+            if_exp: None,
+            timeout: None,
+        }
+    }
+
+    /// Adds an expression that must evaluate to `true` to cancel the run.
+    pub fn if_exp(mut self, if_exp: &str) -> Self {
+        self.if_exp = Some(if_exp.to_string());
+        self
+    }
+
+    /// Restricts how long the cancellation rule remains active.
+    pub fn timeout<T: Into<FunctionTime>>(mut self, timeout: T) -> Self {
+        self.timeout = Some(timeout.into());
+        self
+    }
+}
+
+/// Configures event batching for a function trigger.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct FunctionBatchEvents {
+    #[serde(rename = "maxSize")]
+    pub max_size: u32,
+    pub timeout: FunctionTime,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+}
+
+impl FunctionBatchEvents {
+    /// Creates a batch configuration with the required size and timeout.
+    pub fn new<T: Into<FunctionTime>>(max_size: u32, timeout: T) -> Self {
+        Self {
+            max_size,
+            timeout: timeout.into(),
+            key: None,
+        }
+    }
+
+    /// Partitions batches by the expression result.
+    pub fn key(mut self, key: &str) -> Self {
+        self.key = Some(key.to_string());
+        self
+    }
+}
+
+/// Rate-limits how often a function can run within a period.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct FunctionRateLimit {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+    pub limit: u32,
+    pub period: FunctionTime,
+}
+
+impl FunctionRateLimit {
+    /// Creates a rate-limit configuration with the required limit and period.
+    pub fn new<T: Into<FunctionTime>>(limit: u32, period: T) -> Self {
+        Self {
+            key: None,
+            limit,
+            period: period.into(),
+        }
+    }
+
+    /// Partitions rate limits by the expression result.
+    pub fn key(mut self, key: &str) -> Self {
+        self.key = Some(key.to_string());
+        self
+    }
+}
+
+/// Debounces function execution until a quiet period has elapsed.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct FunctionDebounce {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+    pub period: FunctionTime,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout: Option<FunctionTime>,
+}
+
+impl FunctionDebounce {
+    /// Creates a debounce configuration with the required quiet period.
+    pub fn new<T: Into<FunctionTime>>(period: T) -> Self {
+        Self {
+            key: None,
+            period: period.into(),
+            timeout: None,
+        }
+    }
+
+    /// Partitions debounce state by the expression result.
+    pub fn key(mut self, key: &str) -> Self {
+        self.key = Some(key.to_string());
+        self
+    }
+
+    /// Caps how long the debounce window can continue to extend.
+    pub fn timeout<T: Into<FunctionTime>>(mut self, timeout: T) -> Self {
+        self.timeout = Some(timeout.into());
+        self
+    }
+}
+
+/// Controls execution priority relative to other queued runs.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct FunctionPriority {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run: Option<String>,
+}
+
+impl FunctionPriority {
+    /// Creates an empty priority configuration.
+    pub fn new() -> Self {
+        Self { run: None }
+    }
+
+    /// Sets the expression used to determine run priority.
+    pub fn run(mut self, run: &str) -> Self {
+        self.run = Some(run.to_string());
+        self
+    }
+}
+
+impl Default for FunctionPriority {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Defines how a keyed concurrency group is scoped.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub enum FunctionConcurrencyScope {
+    #[serde(rename = "fn")]
+    Function,
+    #[serde(rename = "env")]
+    Env,
+    #[serde(rename = "account")]
+    Account,
+}
+
+/// Configures one keyed concurrency limit.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct FunctionConcurrencyOption {
+    pub limit: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<FunctionConcurrencyScope>,
+}
+
+impl FunctionConcurrencyOption {
+    /// Creates a keyed concurrency option with the required limit.
+    pub fn new(limit: u32) -> Self {
+        Self {
+            limit,
+            key: None,
+            scope: None,
+        }
+    }
+
+    /// Partitions concurrency groups by the expression result.
+    pub fn key(mut self, key: &str) -> Self {
+        self.key = Some(key.to_string());
+        self
+    }
+
+    /// Sets the scope for the concurrency group.
+    pub fn scope(mut self, scope: FunctionConcurrencyScope) -> Self {
+        self.scope = Some(scope);
+        self
+    }
+}
+
+/// Configures how function executions are concurrency-limited.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum FunctionConcurrency {
+    Limit(u32),
+    Keyed(Vec<FunctionConcurrencyOption>),
+}
+
+impl FunctionConcurrency {
+    /// Creates a concurrency configuration using the numeric shorthand.
+    pub fn limit(limit: u32) -> Self {
+        Self::Limit(limit)
+    }
+
+    /// Creates a concurrency configuration using keyed options.
+    pub fn keyed(options: Vec<FunctionConcurrencyOption>) -> Self {
+        Self::Keyed(options)
+    }
+}
+
+/// Throttles function execution to a steady rate.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct FunctionThrottle {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+    pub limit: u32,
+    pub period: FunctionTime,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub burst: Option<u32>,
+}
+
+impl FunctionThrottle {
+    /// Creates a throttle configuration with the required limit and period.
+    pub fn new<T: Into<FunctionTime>>(limit: u32, period: T) -> Self {
+        Self {
+            key: None,
+            limit,
+            period: period.into(),
+            burst: None,
+        }
+    }
+
+    /// Partitions throttle groups by the expression result.
+    pub fn key(mut self, key: &str) -> Self {
+        self.key = Some(key.to_string());
+        self
+    }
+
+    /// Sets the burst capacity allowed above the steady-state rate.
+    pub fn burst(mut self, burst: u32) -> Self {
+        self.burst = Some(burst);
+        self
+    }
+}
+
+/// Determines how singleton runs behave when a duplicate key is triggered.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum FunctionSingletonMode {
+    Skip,
+    Cancel,
+}
+
+/// Ensures only one run per singleton key is active at a time.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct FunctionSingleton {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+    pub mode: FunctionSingletonMode,
+}
+
+impl FunctionSingleton {
+    /// Creates a singleton configuration with the required behavior mode.
+    pub fn new(mode: FunctionSingletonMode) -> Self {
+        Self { key: None, mode }
+    }
+
+    /// Partitions singleton groups by the expression result.
+    pub fn key(mut self, key: &str) -> Self {
+        self.key = Some(key.to_string());
+        self
+    }
+}
+
+/// Controls how long a function can wait to start or finish.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct FunctionTimeouts {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start: Option<FunctionTime>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finish: Option<FunctionTime>,
+}
+
+impl FunctionTimeouts {
+    /// Creates an empty timeout configuration.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the maximum time from trigger to first execution attempt.
+    pub fn start<T: Into<FunctionTime>>(mut self, start: T) -> Self {
+        self.start = Some(start.into());
+        self
+    }
+
+    /// Sets the maximum total runtime allowed for the function.
+    pub fn finish<T: Into<FunctionTime>>(mut self, finish: T) -> Self {
+        self.finish = Some(finish.into());
+        self
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct FunctionOpts {
     pub id: String,
     pub name: Option<String>,
     pub retries: u8,
+    pub cancel: Vec<FunctionCancel>,
+    pub idempotency: Option<String>,
+    pub batch_events: Option<FunctionBatchEvents>,
+    pub rate_limit: Option<FunctionRateLimit>,
+    pub debounce: Option<FunctionDebounce>,
+    pub priority: Option<FunctionPriority>,
+    pub concurrency: Option<FunctionConcurrency>,
+    pub throttle: Option<FunctionThrottle>,
+    pub singleton: Option<FunctionSingleton>,
+    pub timeouts: Option<FunctionTimeouts>,
 }
 
 impl Default for FunctionOpts {
@@ -39,6 +408,16 @@ impl Default for FunctionOpts {
             id: String::new(),
             name: None,
             retries: 3,
+            cancel: Vec::new(),
+            idempotency: None,
+            batch_events: None,
+            rate_limit: None,
+            debounce: None,
+            priority: None,
+            concurrency: None,
+            throttle: None,
+            singleton: None,
+            timeouts: None,
         }
     }
 }
@@ -61,6 +440,66 @@ impl FunctionOpts {
     /// Overrides the number of retry attempts the executor should schedule.
     pub fn retries(mut self, retries: u8) -> Self {
         self.retries = retries;
+        self
+    }
+
+    /// Adds a cancellation rule to the function definition.
+    pub fn cancel(mut self, cancel: FunctionCancel) -> Self {
+        self.cancel.push(cancel);
+        self
+    }
+
+    /// Sets an idempotency expression for the function.
+    pub fn idempotency(mut self, idempotency: &str) -> Self {
+        self.idempotency = Some(idempotency.to_string());
+        self
+    }
+
+    /// Configures event batching for the function trigger.
+    pub fn batch_events(mut self, batch_events: FunctionBatchEvents) -> Self {
+        self.batch_events = Some(batch_events);
+        self
+    }
+
+    /// Configures rate-limiting for the function.
+    pub fn rate_limit(mut self, rate_limit: FunctionRateLimit) -> Self {
+        self.rate_limit = Some(rate_limit);
+        self
+    }
+
+    /// Configures debouncing for the function.
+    pub fn debounce(mut self, debounce: FunctionDebounce) -> Self {
+        self.debounce = Some(debounce);
+        self
+    }
+
+    /// Configures execution priority for the function.
+    pub fn priority(mut self, priority: FunctionPriority) -> Self {
+        self.priority = Some(priority);
+        self
+    }
+
+    /// Configures concurrency limits for the function.
+    pub fn concurrency(mut self, concurrency: FunctionConcurrency) -> Self {
+        self.concurrency = Some(concurrency);
+        self
+    }
+
+    /// Configures throttling for the function.
+    pub fn throttle(mut self, throttle: FunctionThrottle) -> Self {
+        self.throttle = Some(throttle);
+        self
+    }
+
+    /// Configures singleton execution for the function.
+    pub fn singleton(mut self, singleton: FunctionSingleton) -> Self {
+        self.singleton = Some(singleton);
+        self
+    }
+
+    /// Configures execution timeouts for the function.
+    pub fn timeouts(mut self, timeouts: FunctionTimeouts) -> Self {
+        self.timeouts = Some(timeouts);
         self
     }
 }
@@ -130,6 +569,20 @@ impl<T, E> ServableFn<T, E> {
             name,
             triggers: vec![self.trigger.clone()],
             steps,
+            cancel: self.opts.cancel.clone(),
+            idempotency: self.opts.idempotency.clone(),
+            batch_events: self.opts.batch_events.clone(),
+            rate_limit: if self.opts.idempotency.is_some() {
+                None
+            } else {
+                self.opts.rate_limit.clone()
+            },
+            debounce: self.opts.debounce.clone(),
+            priority: self.opts.priority.clone(),
+            concurrency: self.opts.concurrency.clone(),
+            throttle: self.opts.throttle.clone(),
+            singleton: self.opts.singleton.clone(),
+            timeouts: self.opts.timeouts.clone(),
         }
     }
 }
@@ -140,6 +593,26 @@ pub struct Function {
     pub name: String,
     pub triggers: Vec<Trigger>,
     pub steps: HashMap<String, Step>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cancel: Vec<FunctionCancel>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub idempotency: Option<String>,
+    #[serde(rename = "batchEvents", skip_serializing_if = "Option::is_none")]
+    pub batch_events: Option<FunctionBatchEvents>,
+    #[serde(rename = "rateLimit", skip_serializing_if = "Option::is_none")]
+    pub rate_limit: Option<FunctionRateLimit>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub debounce: Option<FunctionDebounce>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<FunctionPriority>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub concurrency: Option<FunctionConcurrency>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub throttle: Option<FunctionThrottle>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub singleton: Option<FunctionSingleton>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeouts: Option<FunctionTimeouts>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/inngest/src/function.rs
+++ b/inngest/src/function.rs
@@ -4,7 +4,7 @@ use crate::{
     step_tool::Step as StepTool,
     utils::duration,
 };
-use futures::future::BoxFuture;
+use futures::{future::BoxFuture, FutureExt};
 use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use slug::slugify;
@@ -25,6 +25,30 @@ pub struct InputCtx {
     pub run_id: String,
     pub step_id: String,
     pub attempt: u8,
+}
+
+/// Error information attached to an `inngest/function.failed` event.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct FunctionFailureError {
+    #[serde(default, rename = "__serialized")]
+    pub serialized: bool,
+    #[serde(default)]
+    pub error: String,
+    #[serde(default)]
+    pub message: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stack: Option<String>,
+}
+
+/// The payload carried by the `inngest/function.failed` system event.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct FunctionFailureEvent<T: 'static> {
+    pub error: FunctionFailureError,
+    pub event: Event<T>,
+    pub function_id: String,
+    pub run_id: String,
 }
 
 /// A function-config time value accepted by the sync payload.
@@ -533,6 +557,7 @@ pub struct ServableFn<T: 'static, E> {
     pub opts: FunctionOpts,
     pub trigger: Trigger,
     pub func: Box<Func<T, E>>,
+    pub(crate) on_failure: Option<Box<Func<FunctionFailureEvent<T>, E>>>,
 }
 
 impl<T: InngestEvent, E> Debug for ServableFn<T, E> {
@@ -559,6 +584,20 @@ impl<T, E> ServableFn<T, E> {
 
     pub fn trigger(&self) -> Trigger {
         self.trigger.clone()
+    }
+
+    /// Registers a Rust-style `on_failure` handler for this function.
+    ///
+    /// The handler is synced as a separate internal function triggered by the
+    /// `inngest/function.failed` system event. The internal function uses its
+    /// own retry policy and does not inherit concurrency or singleton settings
+    /// from the parent function.
+    pub fn on_failure<F: futures::Future<Output = Result<Value, E>> + Send + Sync + 'static>(
+        mut self,
+        func: impl Fn(Input<FunctionFailureEvent<T>>, StepTool) -> F + Send + Sync + 'static,
+    ) -> Self {
+        self.on_failure = Some(Box::new(move |input, step| func(input, step).boxed()));
+        self
     }
 
     pub fn function(&self, serve_origin: &str, serve_path: &str) -> Function {
@@ -739,7 +778,7 @@ pub struct StepRetry {
     pub attempts: u8,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum Trigger {
     EventTrigger {

--- a/inngest/src/handler.rs
+++ b/inngest/src/handler.rs
@@ -14,7 +14,7 @@ use crate::{
     event::{Event, InngestEvent},
     function::{Function, FunctionOpts, Input, InputCtx, ServableFn, Trigger},
     header::{self, Headers},
-    result::{Error, FlowControlVariant, SdkResponse},
+    result::{DevError, Error, FlowControlVariant, SdkResponse},
     sdk::Request,
     signature::Signature,
     step_tool::Step as StepTool,
@@ -409,7 +409,7 @@ impl Handler {
         framework: &str,
         raw_body: &str,
     ) -> Result<IntrospectResult, Error> {
-        let payload = self.sync_payload(headers, framework);
+        let payload = self.sync_payload(headers, framework)?;
         let function_count = payload.functions.len() as u32;
         let has_event_key = self.has_event_key();
         let has_signing_key = self.has_signing_key();
@@ -504,7 +504,7 @@ impl Handler {
         key.and_then(|key| Signature::new(&key).hash().ok())
     }
 
-    fn sync_payload(&self, headers: &Headers, framework: &str) -> Request {
+    fn sync_payload(&self, headers: &Headers, framework: &str) -> Result<Request, Error> {
         let app_id = self.inngest.app_id();
         let functions: Vec<Function> = self
             .funcs
@@ -512,7 +512,13 @@ impl Handler {
             .map(|f| f.function(&self.app_serve_origin(headers), &self.app_serve_path()))
             .collect();
 
-        Request {
+        for function in &functions {
+            function
+                .validate()
+                .map_err(|err| basic_error!("invalid function config: {}", err))?;
+        }
+
+        Ok(Request {
             app_name: app_id.clone(),
             framework: framework.to_string(),
             functions,
@@ -522,7 +528,7 @@ impl Handler {
                 self.app_serve_path()
             ),
             ..Default::default()
-        }
+        })
     }
 
     pub async fn sync(
@@ -531,7 +537,12 @@ impl Handler {
         query: &SyncQueryParams,
         framework: &str,
     ) -> Result<SyncResponse, String> {
-        let req = self.sync_payload(_headers, framework);
+        let req = self
+            .sync_payload(_headers, framework)
+            .map_err(|err| match err {
+                Error::Dev(DevError::Basic(message)) => message,
+                other => format!("{other:?}"),
+            })?;
         let sync_url = format!(
             "{}/fn/register",
             self.inngest.inngest_api_origin().trim_end_matches('/')
@@ -1201,7 +1212,9 @@ mod tests {
 
         handler.register_fns(vec![first_fn.into(), second_fn.into()]);
 
-        let payload = handler.sync_payload(&Headers::from(HeaderMap::new()), "axum");
+        let payload = handler
+            .sync_payload(&Headers::from(HeaderMap::new()), "axum")
+            .expect("sync payload should serialize");
         let function_ids: HashSet<String> = payload
             .functions
             .into_iter()
@@ -1231,7 +1244,9 @@ mod tests {
 
         handler.register_fn(first_fn);
 
-        let payload = handler.sync_payload(&Headers::from(HeaderMap::new()), "axum");
+        let payload = handler
+            .sync_payload(&Headers::from(HeaderMap::new()), "axum")
+            .expect("sync payload should serialize");
         let function = payload
             .functions
             .into_iter()
@@ -1299,7 +1314,9 @@ mod tests {
 
         handler.register_fn(func);
 
-        let payload = handler.sync_payload(&Headers::from(HeaderMap::new()), "axum");
+        let payload = handler
+            .sync_payload(&Headers::from(HeaderMap::new()), "axum")
+            .expect("sync payload should serialize");
         let function = payload
             .functions
             .into_iter()
@@ -1385,7 +1402,9 @@ mod tests {
 
         handler.register_fn(func);
 
-        let payload = handler.sync_payload(&Headers::from(HeaderMap::new()), "axum");
+        let payload = handler
+            .sync_payload(&Headers::from(HeaderMap::new()), "axum")
+            .expect("sync payload should serialize");
         let function = payload
             .functions
             .into_iter()
@@ -1395,6 +1414,72 @@ mod tests {
 
         assert_eq!(serialized["idempotency"], json!("event.data.id"));
         assert!(serialized.get("rateLimit").is_none());
+    }
+
+    #[test]
+    fn sync_payload_rejects_batch_configs_outside_spec_limits() {
+        let client = Inngest::new("test-app");
+        let mut handler = Handler::new(&client);
+
+        let func: ServableFn<FirstEvent, Error> = client.create_function(
+            FunctionOpts::new("first")
+                .batch_events(FunctionBatchEvents::new(101, Duration::from_secs(0))),
+            Trigger::event("test/first"),
+            |_input: Input<FirstEvent>, _step| async move { Ok(json!({ "ok": true })) },
+        );
+
+        handler.register_fn(func);
+
+        let error = handler
+            .sync_payload(&Headers::from(HeaderMap::new()), "axum")
+            .expect_err("invalid batch config should be rejected");
+
+        assert_basic_error(error, "batchEvents.maxSize must be between 1 and 100");
+    }
+
+    #[test]
+    fn sync_payload_rejects_batch_timeout_outside_spec_limits() {
+        let client = Inngest::new("test-app");
+        let mut handler = Handler::new(&client);
+
+        let func: ServableFn<FirstEvent, Error> = client.create_function(
+            FunctionOpts::new("first")
+                .batch_events(FunctionBatchEvents::new(10, Duration::from_secs(61))),
+            Trigger::event("test/first"),
+            |_input: Input<FirstEvent>, _step| async move { Ok(json!({ "ok": true })) },
+        );
+
+        handler.register_fn(func);
+
+        let error = handler
+            .sync_payload(&Headers::from(HeaderMap::new()), "axum")
+            .expect_err("invalid batch timeout should be rejected");
+
+        assert_basic_error(error, "batchEvents.timeout must be between 1s and 60s");
+    }
+
+    #[test]
+    fn sync_payload_rejects_concurrency_with_more_than_two_keyed_limits() {
+        let client = Inngest::new("test-app");
+        let mut handler = Handler::new(&client);
+
+        let func: ServableFn<FirstEvent, Error> = client.create_function(
+            FunctionOpts::new("first").concurrency(FunctionConcurrency::keyed(vec![
+                FunctionConcurrencyOption::new(1),
+                FunctionConcurrencyOption::new(2),
+                FunctionConcurrencyOption::new(3),
+            ])),
+            Trigger::event("test/first"),
+            |_input: Input<FirstEvent>, _step| async move { Ok(json!({ "ok": true })) },
+        );
+
+        handler.register_fn(func);
+
+        let error = handler
+            .sync_payload(&Headers::from(HeaderMap::new()), "axum")
+            .expect_err("invalid concurrency config should be rejected");
+
+        assert_basic_error(error, "concurrency supports at most two keyed options");
     }
 
     #[tokio::test]

--- a/inngest/src/handler.rs
+++ b/inngest/src/handler.rs
@@ -66,6 +66,20 @@ impl DynamicServableFn {
             name,
             triggers: vec![self.trigger.clone()],
             steps,
+            cancel: self.opts.cancel.clone(),
+            idempotency: self.opts.idempotency.clone(),
+            batch_events: self.opts.batch_events.clone(),
+            rate_limit: if self.opts.idempotency.is_some() {
+                None
+            } else {
+                self.opts.rate_limit.clone()
+            },
+            debounce: self.opts.debounce.clone(),
+            priority: self.opts.priority.clone(),
+            concurrency: self.opts.concurrency.clone(),
+            throttle: self.opts.throttle.clone(),
+            singleton: self.opts.singleton.clone(),
+            timeouts: self.opts.timeouts.clone(),
         }
     }
 
@@ -902,7 +916,11 @@ fn run_request_uses_api(body: &Value) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::function::ServableFn;
+    use crate::function::{
+        FunctionBatchEvents, FunctionCancel, FunctionConcurrency, FunctionConcurrencyOption,
+        FunctionConcurrencyScope, FunctionDebounce, FunctionPriority, FunctionRateLimit,
+        FunctionSingleton, FunctionSingletonMode, FunctionThrottle, FunctionTimeouts, ServableFn,
+    };
     use axum::{
         extract::State,
         http::{HeaderMap, StatusCode, Uri},
@@ -1229,6 +1247,154 @@ mod tests {
             "http://127.0.0.1:3000/api/inngest?fnId=test-app-first&stepId=step"
         );
         assert!(!payload.url.contains("deployId="));
+    }
+
+    #[test]
+    fn sync_payload_serializes_function_config_metadata() {
+        let client = Inngest::new("test-app");
+        let mut handler = Handler::new(&client);
+
+        let func: ServableFn<FirstEvent, Error> = client.create_function(
+            FunctionOpts::new("first")
+                .cancel(
+                    FunctionCancel::new("app/cancel")
+                        .if_exp("event.data.id == async.data.id")
+                        .timeout(Duration::from_secs(30)),
+                )
+                .batch_events(
+                    FunctionBatchEvents::new(10, Duration::from_secs(45))
+                        .key("event.data.account_id"),
+                )
+                .rate_limit(
+                    FunctionRateLimit::new(5, Duration::from_secs(60)).key("event.data.user_id"),
+                )
+                .debounce(
+                    FunctionDebounce::new(Duration::from_secs(5))
+                        .key("event.data.session_id")
+                        .timeout(Duration::from_secs(30)),
+                )
+                .priority(FunctionPriority::new().run("event.data.priority"))
+                .concurrency(FunctionConcurrency::keyed(vec![
+                    FunctionConcurrencyOption::new(3)
+                        .key("event.data.account_id")
+                        .scope(FunctionConcurrencyScope::Env),
+                ]))
+                .throttle(
+                    FunctionThrottle::new(10, Duration::from_secs(60))
+                        .key("event.data.region")
+                        .burst(2),
+                )
+                .singleton(
+                    FunctionSingleton::new(FunctionSingletonMode::Cancel)
+                        .key("event.data.workflow_id"),
+                )
+                .timeouts(
+                    FunctionTimeouts::new()
+                        .start(Duration::from_secs(30))
+                        .finish(Duration::from_secs(300)),
+                ),
+            Trigger::event("test/first"),
+            |_input: Input<FirstEvent>, _step| async move { Ok(json!({ "ok": true })) },
+        );
+
+        handler.register_fn(func);
+
+        let payload = handler.sync_payload(&Headers::from(HeaderMap::new()), "axum");
+        let function = payload
+            .functions
+            .into_iter()
+            .next()
+            .expect("registered function should be present");
+        let serialized = serde_json::to_value(function).expect("function should serialize");
+
+        assert_eq!(
+            serialized,
+            json!({
+                "id": "test-app-first",
+                "name": "test-app-first",
+                "triggers": [{ "event": "test/first", "expression": null }],
+                "steps": {
+                    "step": {
+                        "id": "step",
+                        "name": "step",
+                        "runtime": {
+                            "url": "http://127.0.0.1:3000/api/inngest?fnId=test-app-first&stepId=step",
+                            "type": "http"
+                        },
+                        "retries": { "attempts": 3 }
+                    }
+                },
+                "cancel": [{
+                    "event": "app/cancel",
+                    "if": "event.data.id == async.data.id",
+                    "timeout": "30s"
+                }],
+                "batchEvents": {
+                    "maxSize": 10,
+                    "timeout": "45s",
+                    "key": "event.data.account_id"
+                },
+                "rateLimit": {
+                    "key": "event.data.user_id",
+                    "limit": 5,
+                    "period": "1m"
+                },
+                "debounce": {
+                    "key": "event.data.session_id",
+                    "period": "5s",
+                    "timeout": "30s"
+                },
+                "priority": {
+                    "run": "event.data.priority"
+                },
+                "concurrency": [{
+                    "limit": 3,
+                    "key": "event.data.account_id",
+                    "scope": "env"
+                }],
+                "throttle": {
+                    "key": "event.data.region",
+                    "limit": 10,
+                    "period": "1m",
+                    "burst": 2
+                },
+                "singleton": {
+                    "key": "event.data.workflow_id",
+                    "mode": "cancel"
+                },
+                "timeouts": {
+                    "start": "30s",
+                    "finish": "5m"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn sync_payload_omits_rate_limit_when_idempotency_is_set() {
+        let client = Inngest::new("test-app");
+        let mut handler = Handler::new(&client);
+
+        let func: ServableFn<FirstEvent, Error> = client.create_function(
+            FunctionOpts::new("first")
+                .idempotency("event.data.id")
+                .rate_limit(FunctionRateLimit::new(5, Duration::from_secs(60))),
+            Trigger::event("test/first"),
+            |_input: Input<FirstEvent>, _step| async move { Ok(json!({ "ok": true })) },
+        );
+
+        handler.register_fn(func);
+
+        let payload = handler.sync_payload(&Headers::from(HeaderMap::new()), "axum");
+        let function = payload
+            .functions
+            .into_iter()
+            .next()
+            .expect("registered function should be present");
+        let serialized = serde_json::to_value(function).expect("function should serialize");
+
+        assert_eq!(serialized["idempotency"], json!("event.data.id"));
+        assert!(serialized.get("rateLimit").is_none());
     }
 
     #[tokio::test]

--- a/inngest/src/handler.rs
+++ b/inngest/src/handler.rs
@@ -1023,6 +1023,7 @@ mod tests {
     #[derive(Clone, Debug, Default, PartialEq, Eq)]
     struct SyncRequestRecord {
         authorization: Option<String>,
+        body: Value,
         env: Option<String>,
         path: String,
         query: Option<String>,
@@ -1845,6 +1846,159 @@ mod tests {
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].path, "/fn/register");
         assert_eq!(records[0].query, Some("deployId=deploy-123".to_string()));
+    }
+
+    #[tokio::test]
+    async fn sync_sends_function_config_metadata_in_request_body() {
+        let (origin, records) =
+            spawn_sync_server(vec![(StatusCode::OK, sync_success_body())]).await;
+        let client = Inngest::new("test-app").api_origin(&origin);
+        let mut handler = Handler::new(&client);
+
+        let func: ServableFn<FirstEvent, Error> = client
+            .create_function(
+                FunctionOpts::new("first")
+                    .cancel(
+                        FunctionCancel::new("app/cancel")
+                            .if_exp("event.data.id == async.data.id")
+                            .timeout(Duration::from_secs(30)),
+                    )
+                    .idempotency("event.data.id")
+                    .rate_limit(
+                        FunctionRateLimit::new(5, Duration::from_secs(60))
+                            .key("event.data.user_id"),
+                    )
+                    .batch_events(
+                        FunctionBatchEvents::new(10, Duration::from_secs(45))
+                            .key("event.data.account_id"),
+                    )
+                    .debounce(
+                        FunctionDebounce::new(Duration::from_secs(5))
+                            .key("event.data.session_id")
+                            .timeout(Duration::from_secs(30)),
+                    )
+                    .priority(FunctionPriority::new().run("event.data.priority"))
+                    .concurrency(FunctionConcurrency::keyed(vec![
+                        FunctionConcurrencyOption::new(3)
+                            .key("event.data.account_id")
+                            .scope(FunctionConcurrencyScope::Env),
+                    ]))
+                    .throttle(
+                        FunctionThrottle::new(10, Duration::from_secs(60))
+                            .key("event.data.region")
+                            .burst(2),
+                    )
+                    .singleton(
+                        FunctionSingleton::new(FunctionSingletonMode::Cancel)
+                            .key("event.data.workflow_id"),
+                    )
+                    .timeouts(
+                        FunctionTimeouts::new()
+                            .start(Duration::from_secs(30))
+                            .finish(Duration::from_secs(300)),
+                    ),
+                Trigger::event("test/first"),
+                |_input: Input<FirstEvent>, _step| async move { Ok(json!({ "ok": true })) },
+            )
+            .on_failure(
+                |input: Input<FunctionFailureEvent<FirstEvent>>, _step| async move {
+                    Ok(json!({ "failed": input.event.data.function_id }))
+                },
+            );
+        handler.register_fn(func);
+
+        let result = handler
+            .sync(
+                &Headers::from(HeaderMap::new()),
+                &SyncQueryParams { deploy_id: None },
+                "axum",
+            )
+            .await
+            .expect("sync should succeed");
+
+        match result {
+            SyncResponse::OutOfBand(result) => assert!(result.modified),
+            SyncResponse::InBand(_) => panic!("sync should use the out-of-band response"),
+        }
+
+        let records = records.lock().await;
+        assert_eq!(records.len(), 1);
+
+        let functions = records[0].body["functions"]
+            .as_array()
+            .expect("sync request should include functions");
+        assert_eq!(functions.len(), 2);
+
+        let main_function = functions
+            .iter()
+            .find(|function| function["id"] == "test-app-first")
+            .expect("main function should be synced");
+        assert_eq!(main_function["cancel"][0]["event"], json!("app/cancel"));
+        assert_eq!(
+            main_function["batchEvents"],
+            json!({
+                "maxSize": 10,
+                "timeout": "45s",
+                "key": "event.data.account_id"
+            })
+        );
+        assert_eq!(main_function["idempotency"], json!("event.data.id"));
+        assert!(main_function.get("rateLimit").is_none());
+        assert_eq!(
+            main_function["debounce"],
+            json!({
+                "key": "event.data.session_id",
+                "period": "5s",
+                "timeout": "30s"
+            })
+        );
+        assert_eq!(main_function["priority"], json!({ "run": "event.data.priority" }));
+        assert_eq!(
+            main_function["concurrency"],
+            json!([{
+                "limit": 3,
+                "key": "event.data.account_id",
+                "scope": "env"
+            }])
+        );
+        assert_eq!(
+            main_function["throttle"],
+            json!({
+                "key": "event.data.region",
+                "limit": 10,
+                "period": "1m",
+                "burst": 2
+            })
+        );
+        assert_eq!(
+            main_function["singleton"],
+            json!({
+                "key": "event.data.workflow_id",
+                "mode": "cancel"
+            })
+        );
+        assert_eq!(
+            main_function["timeouts"],
+            json!({
+                "start": "30s",
+                "finish": "5m"
+            })
+        );
+
+        let failure_function = functions
+            .iter()
+            .find(|function| function["id"] == "test-app-first-failure")
+            .expect("failure function should be synced");
+        assert_eq!(
+            failure_function["triggers"],
+            json!([{
+                "event": "inngest/function.failed",
+                "expression": "event.data.function_id == \"test-app-first\""
+            }])
+        );
+        assert_eq!(failure_function["steps"]["step"]["retries"], json!({ "attempts": 0 }));
+        assert!(failure_function.get("concurrency").is_none());
+        assert!(failure_function.get("singleton").is_none());
     }
 
     #[tokio::test]
@@ -2722,6 +2876,7 @@ mod tests {
         ) -> impl IntoResponse {
             state.records.lock().await.push(SyncRequestRecord {
                 authorization: header_value(&headers, "authorization"),
+                body: Value::Null,
                 env: header_value(&headers, header::INNGEST_ENV),
                 path: uri.path().to_string(),
                 query: uri.query().map(|query| query.to_string()),
@@ -2744,6 +2899,7 @@ mod tests {
         ) -> impl IntoResponse {
             state.records.lock().await.push(SyncRequestRecord {
                 authorization: header_value(&headers, "authorization"),
+                body: Value::Null,
                 env: header_value(&headers, header::INNGEST_ENV),
                 path: uri.path().to_string(),
                 query: uri.query().map(|query| query.to_string()),
@@ -2787,9 +2943,11 @@ mod tests {
         State(state): State<SyncServerState>,
         headers: HeaderMap,
         uri: Uri,
+        body: String,
     ) -> (StatusCode, String) {
         state.records.lock().await.push(SyncRequestRecord {
             authorization: header_value(&headers, "authorization"),
+            body: serde_json::from_str(&body).expect("sync request body should be valid JSON"),
             env: header_value(&headers, header::INNGEST_ENV),
             path: uri.path().to_string(),
             query: uri.query().map(|query| query.to_string()),

--- a/inngest/src/handler.rs
+++ b/inngest/src/handler.rs
@@ -1952,7 +1952,10 @@ mod tests {
                 "timeout": "30s"
             })
         );
-        assert_eq!(main_function["priority"], json!({ "run": "event.data.priority" }));
+        assert_eq!(
+            main_function["priority"],
+            json!({ "run": "event.data.priority" })
+        );
         assert_eq!(
             main_function["concurrency"],
             json!([{
@@ -1996,7 +1999,10 @@ mod tests {
                 "expression": "event.data.function_id == \"test-app-first\""
             }])
         );
-        assert_eq!(failure_function["steps"]["step"]["retries"], json!({ "attempts": 0 }));
+        assert_eq!(
+            failure_function["steps"]["step"]["retries"],
+            json!({ "attempts": 0 })
+        );
         assert!(failure_function.get("concurrency").is_none());
         assert!(failure_function.get("singleton").is_none());
     }

--- a/inngest/src/handler.rs
+++ b/inngest/src/handler.rs
@@ -25,6 +25,8 @@ type DynamicFn = dyn Fn(RunQueryParams, Value) -> BoxFuture<'static, Result<SdkR
     + Send
     + Sync
     + 'static;
+type RegisteredFunc<T, E> =
+    dyn Fn(Input<T>, StepTool) -> BoxFuture<'static, Result<Value, E>> + Send + Sync + 'static;
 
 struct DynamicServableFn {
     app_id: String,
@@ -92,99 +94,97 @@ impl DynamicServableFn {
 ///
 /// Convert a [`ServableFn`] into a `RegisteredFn` with `.into()` when batching
 /// functions that use different event payload or error types.
-pub struct RegisteredFn(DynamicServableFn);
+pub struct RegisteredFn(Vec<DynamicServableFn>);
 
 impl RegisteredFn {
-    fn into_dynamic(self) -> DynamicServableFn {
+    fn into_dynamics(self) -> Vec<DynamicServableFn> {
         self.0
     }
 }
 
-impl<T, E> From<ServableFn<T, E>> for DynamicServableFn
+fn make_dynamic_fn<T, E>(
+    app_id: String,
+    client: Inngest,
+    opts: FunctionOpts,
+    trigger: Trigger,
+    func: Box<RegisteredFunc<T, E>>,
+) -> DynamicServableFn
 where
     T: InngestEvent + Send,
     E: Into<Error> + 'static,
 {
-    fn from(func: ServableFn<T, E>) -> Self {
-        let ServableFn {
-            app_id,
-            client,
-            opts,
-            trigger,
-            func,
-        } = func;
-        let func = Arc::new(func);
+    let func = Arc::new(func);
 
-        Self {
-            app_id,
-            opts,
-            trigger,
-            func: Box::new(move |query, body| {
-                let step_func = Arc::clone(&func);
-                let client = client.clone();
+    DynamicServableFn {
+        app_id,
+        opts,
+        trigger,
+        func: Box::new(move |query, body| {
+            let step_func = Arc::clone(&func);
+            let client = client.clone();
 
-                async move {
-                    let data = match serde_json::from_value::<RunRequestBody<T>>(body.clone()) {
-                        Ok(res) => res,
-                        Err(err) => {
-                            println!("ERROR: {:?}", err);
-                            println!("BODY: {:#?}", &body);
-                            let msg = basic_error!("error parsing run request: {}", err);
-                            return Err(msg);
-                        }
-                    };
+            async move {
+                let data = match serde_json::from_value::<RunRequestBody<T>>(body.clone()) {
+                    Ok(res) => res,
+                    Err(err) => {
+                        println!("ERROR: {:?}", err);
+                        println!("BODY: {:#?}", &body);
+                        let msg = basic_error!("error parsing run request: {}", err);
+                        return Err(msg);
+                    }
+                };
 
-                    let input = Input {
-                        event: data.event,
-                        events: data.events,
-                        ctx: InputCtx {
-                            env: data.ctx.env.clone(),
-                            fn_id: query.fn_id.clone(),
-                            run_id: data.ctx.run_id.clone(),
-                            step_id: query.step_id.clone(),
-                            attempt: data.ctx.attempt,
-                        },
-                    };
+                let input = Input {
+                    event: data.event,
+                    events: data.events,
+                    ctx: InputCtx {
+                        env: data.ctx.env.clone(),
+                        fn_id: query.fn_id.clone(),
+                        run_id: data.ctx.run_id.clone(),
+                        step_id: query.step_id.clone(),
+                        attempt: data.ctx.attempt,
+                    },
+                };
 
-                    let step_tool = StepTool::new_with_execution_mode(
-                        client.clone(),
-                        &data.steps,
-                        &query.step_id,
-                        &data.ctx.stack.stack,
-                        data.ctx.disable_immediate_execution,
-                    );
+                let step_tool = StepTool::new_with_execution_mode(
+                    client.clone(),
+                    &data.steps,
+                    &query.step_id,
+                    &data.ctx.stack.stack,
+                    data.ctx.disable_immediate_execution,
+                );
 
-                    match std::panic::catch_unwind(AssertUnwindSafe(|| {
-                        (step_func.as_ref())(input, step_tool.clone())
-                    })) {
-                        Ok(fut) => match AssertUnwindSafe(fut).catch_unwind().await {
-                            Ok(v) => match v {
-                                Ok(v) => {
-                                    if query.step_id != default_step_id()
-                                        && step_tool.step_seen()
-                                        && !step_tool.target_found()
-                                    {
-                                        return Ok(SdkResponse {
-                                            status: 206,
-                                            body: json!([{
-                                                "id": query.step_id,
-                                                "op": "StepNotFound"
-                                            }]),
-                                        });
-                                    }
-
-                                    Ok(SdkResponse {
-                                        status: 200,
-                                        body: v,
-                                    })
+                match std::panic::catch_unwind(AssertUnwindSafe(|| {
+                    (step_func.as_ref())(input, step_tool.clone())
+                })) {
+                    Ok(fut) => match AssertUnwindSafe(fut).catch_unwind().await {
+                        Ok(v) => match v {
+                            Ok(v) => {
+                                if query.step_id != default_step_id()
+                                    && step_tool.step_seen()
+                                    && !step_tool.target_found()
+                                {
+                                    return Ok(SdkResponse {
+                                        status: 206,
+                                        body: json!([{
+                                            "id": query.step_id,
+                                            "op": "StepNotFound"
+                                        }]),
+                                    });
                                 }
-                                Err(err) => match err.into() {
-                                    Error::Interrupt(mut flow) => {
-                                        flow.acknowledge();
-                                        match flow.variant {
-                                            FlowControlVariant::StepGenerator => {
-                                                let (status, body) = if let Some(step_id) = step_tool.missing_step()
-                                                {
+
+                                Ok(SdkResponse {
+                                    status: 200,
+                                    body: v,
+                                })
+                            }
+                            Err(err) => match err.into() {
+                                Error::Interrupt(mut flow) => {
+                                    flow.acknowledge();
+                                    match flow.variant {
+                                        FlowControlVariant::StepGenerator => {
+                                            let (status, body) =
+                                                if let Some(step_id) = step_tool.missing_step() {
                                                     (
                                                         206,
                                                         json!([{
@@ -197,40 +197,37 @@ where
                                                         Ok(v) => (206, v),
                                                         Err(err) => {
                                                             return Err(basic_error!(
-                                                                "error serializing step response: {}",
-                                                                err
-                                                            ));
+                                                            "error serializing step response: {}",
+                                                            err
+                                                        ));
                                                         }
                                                     }
                                                 } else {
                                                     (206, json!("null"))
                                                 };
-                                                Ok(SdkResponse { status, body })
-                                            }
-                                            FlowControlVariant::ParallelSkip => {
-                                                Err(basic_error!(
-                                                    "parallel skip leaked out of a parallel group"
-                                                ))
-                                            }
+                                            Ok(SdkResponse { status, body })
                                         }
+                                        FlowControlVariant::ParallelSkip => Err(basic_error!(
+                                            "parallel skip leaked out of a parallel group"
+                                        )),
                                     }
-                                    other => Err(other),
-                                },
+                                }
+                                other => Err(other),
                             },
-                            Err(panic_err) => Ok(SdkResponse {
-                                status: 500,
-                                body: Value::String(format!("panic: {:?}", panic_err)),
-                            }),
                         },
                         Err(panic_err) => Ok(SdkResponse {
                             status: 500,
                             body: Value::String(format!("panic: {:?}", panic_err)),
                         }),
-                    }
+                    },
+                    Err(panic_err) => Ok(SdkResponse {
+                        status: 500,
+                        body: Value::String(format!("panic: {:?}", panic_err)),
+                    }),
                 }
-                .boxed()
-            }),
-        }
+            }
+            .boxed()
+        }),
     }
 }
 
@@ -240,7 +237,42 @@ where
     E: Into<Error> + 'static,
 {
     fn from(func: ServableFn<T, E>) -> Self {
-        Self(DynamicServableFn::from(func))
+        let ServableFn {
+            app_id,
+            client,
+            opts,
+            trigger,
+            func,
+            on_failure,
+        } = func;
+
+        let function_id = format!("{}-{}", app_id, slugify(opts.id.clone()));
+        let function_name = opts.name.clone().unwrap_or_else(|| function_id.clone());
+
+        let mut funcs = vec![make_dynamic_fn(
+            app_id.clone(),
+            client.clone(),
+            opts.clone(),
+            trigger,
+            func,
+        )];
+
+        if let Some(on_failure) = on_failure {
+            let failure_opts = FunctionOpts::new(&format!("{}-failure", opts.id))
+                .name(&format!("{} (failure)", function_name))
+                .retries(0);
+
+            funcs.push(make_dynamic_fn(
+                app_id,
+                client,
+                failure_opts,
+                Trigger::event("inngest/function.failed")
+                    .expr(&format!("event.data.function_id == \"{}\"", function_id)),
+                on_failure,
+            ));
+        }
+
+        Self(funcs)
     }
 }
 
@@ -331,8 +363,10 @@ impl Handler {
         T: InngestEvent + Send,
         E: Into<Error> + 'static,
     {
-        let func = DynamicServableFn::from(func);
-        self.funcs.insert(func.slug(), func);
+        let funcs = RegisteredFn::from(func).into_dynamics();
+        for func in funcs {
+            self.funcs.insert(func.slug(), func);
+        }
     }
 
     /// Registers multiple functions with the handler.
@@ -351,8 +385,9 @@ impl Handler {
         I: IntoIterator<Item = RegisteredFn>,
     {
         for f in funcs {
-            let func = f.into_dynamic();
-            self.funcs.insert(func.slug(), func);
+            for func in f.into_dynamics() {
+                self.funcs.insert(func.slug(), func);
+            }
         }
     }
 
@@ -929,8 +964,9 @@ mod tests {
     use super::*;
     use crate::function::{
         FunctionBatchEvents, FunctionCancel, FunctionConcurrency, FunctionConcurrencyOption,
-        FunctionConcurrencyScope, FunctionDebounce, FunctionPriority, FunctionRateLimit,
-        FunctionSingleton, FunctionSingletonMode, FunctionThrottle, FunctionTimeouts, ServableFn,
+        FunctionConcurrencyScope, FunctionDebounce, FunctionFailureEvent, FunctionPriority,
+        FunctionRateLimit, FunctionSingleton, FunctionSingletonMode, FunctionThrottle,
+        FunctionTimeouts, ServableFn,
     };
     use axum::{
         extract::State,
@@ -1417,6 +1453,58 @@ mod tests {
     }
 
     #[test]
+    fn sync_payload_includes_internal_failure_handler_function() {
+        let client = Inngest::new("test-app");
+        let mut handler = Handler::new(&client);
+
+        let func: ServableFn<FirstEvent, Error> = client
+            .create_function(
+                FunctionOpts::new("first"),
+                Trigger::event("test/first"),
+                |_input: Input<FirstEvent>, _step| async move { Ok(json!({ "ok": true })) },
+            )
+            .on_failure(
+                |input: Input<FunctionFailureEvent<FirstEvent>>, _step| async move {
+                    Ok(json!({
+                        "failed": input.event.data.function_id,
+                    }))
+                },
+            );
+
+        handler.register_fn(func);
+
+        let payload = handler
+            .sync_payload(&Headers::from(HeaderMap::new()), "axum")
+            .expect("sync payload should serialize");
+        let functions = payload.functions;
+        let function_ids: HashSet<String> = functions
+            .iter()
+            .map(|function| function.id.clone())
+            .collect();
+
+        assert_eq!(function_ids.len(), 2);
+        assert!(function_ids.contains("test-app-first"));
+        assert!(function_ids.contains("test-app-first-failure"));
+
+        let failure_function = functions
+            .into_iter()
+            .find(|function| function.id == "test-app-first-failure")
+            .expect("failure function should be present");
+
+        assert_eq!(failure_function.name, "test-app-first (failure)");
+        assert_eq!(
+            failure_function.triggers,
+            vec![Trigger::EventTrigger {
+                event: "inngest/function.failed".to_string(),
+                expression: Some("event.data.function_id == \"test-app-first\"".to_string()),
+            }]
+        );
+        assert_eq!(failure_function.steps["step"].retries.attempts, 0);
+        assert!(failure_function.concurrency.is_none());
+        assert!(failure_function.singleton.is_none());
+    }
+
+    #[test]
     fn sync_payload_rejects_batch_configs_outside_spec_limits() {
         let client = Inngest::new("test-app");
         let mut handler = Handler::new(&client);
@@ -1480,6 +1568,82 @@ mod tests {
             .expect_err("invalid concurrency config should be rejected");
 
         assert_basic_error(error, "concurrency supports at most two keyed options");
+    }
+
+    #[tokio::test]
+    async fn handler_runs_internal_failure_handler_functions() {
+        let client = Inngest::new("test-app").dev("1");
+        let mut handler = Handler::new(&client);
+
+        let func: ServableFn<FirstEvent, Error> = client
+            .create_function(
+                FunctionOpts::new("first"),
+                Trigger::event("test/first"),
+                |_input: Input<FirstEvent>, _step| async move { Ok(json!({ "ok": true })) },
+            )
+            .on_failure(
+                |input: Input<FunctionFailureEvent<FirstEvent>>, _step| async move {
+                    Ok(json!({
+                        "message": input.event.data.error.message,
+                        "original": input.event.data.event.data.message,
+                        "failed_function_id": input.event.data.function_id,
+                        "failed_run_id": input.event.data.run_id,
+                    }))
+                },
+            );
+
+        handler.register_fn(func);
+
+        let payload = handler
+            .sync_payload(&Headers::from(HeaderMap::new()), "axum")
+            .expect("sync payload should serialize");
+        let failure_fn_id = payload
+            .functions
+            .into_iter()
+            .find(|function| function.id == "test-app-first-failure")
+            .expect("failure function should be present")
+            .id;
+
+        let body = event_body(
+            "inngest/function.failed",
+            json!({
+                "error": {
+                    "error": "boom",
+                    "message": "boom",
+                    "name": "Error"
+                },
+                "event": {
+                    "id": "evt-1",
+                    "name": "test/first",
+                    "data": { "message": "hello" },
+                    "ts": 123,
+                    "v": null
+                },
+                "function_id": "test-app-first",
+                "run_id": "failed-run-1"
+            }),
+        );
+
+        let response = handler
+            .run(
+                &Headers::from(HeaderMap::new()),
+                &run_query(failure_fn_id),
+                &body.to_string(),
+                &body,
+            )
+            .await
+            .expect("failure handler should run");
+
+        assert_eq!(response.status, 200);
+        assert_eq!(
+            response.body,
+            json!({
+                "message": "boom",
+                "original": "hello",
+                "failed_function_id": "test-app-first",
+                "failed_run_id": "failed-run-1"
+            })
+        );
     }
 
     #[tokio::test]

--- a/inngest/tests/function_config_e2e.rs
+++ b/inngest/tests/function_config_e2e.rs
@@ -6,7 +6,7 @@ use inngest::{
     event::Event,
     function::{
         FunctionBatchEvents, FunctionCancel, FunctionConcurrency, FunctionDebounce,
-        FunctionFailureEvent, FunctionOpts, FunctionRateLimit, FunctionSingleton,
+        FunctionFailureEvent, FunctionOpts, FunctionPriority, FunctionRateLimit, FunctionSingleton,
         FunctionSingletonMode, FunctionThrottle, Input, ServableFn, Trigger,
     },
     result::{DevError, Error},
@@ -68,6 +68,12 @@ struct KeyedEventData {
     message: String,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct PrioritizedEventData {
+    message: String,
+    priority: i32,
+}
+
 #[derive(Debug, Deserialize)]
 struct ApiEnvelope<T> {
     data: T,
@@ -86,14 +92,20 @@ async fn wait_for_value<T: Clone>(
             return value;
         }
 
-        assert!(Instant::now() < deadline, "timed out waiting for state predicate");
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for state predicate"
+        );
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 }
 
 async fn fetch_run_record(run_id: &str) -> Option<e2e_support::RunRecord> {
     let response = reqwest::Client::new()
-        .get(format!("{}/v1/runs/{run_id}", e2e_support::DEV_SERVER_ORIGIN))
+        .get(format!(
+            "{}/v1/runs/{run_id}",
+            e2e_support::DEV_SERVER_ORIGIN
+        ))
         .send()
         .await
         .expect("run lookup should complete");
@@ -459,6 +471,106 @@ async fn debounce_runs_once_with_the_latest_event_payload() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn priority_prefers_higher_priority_runs_once_concurrency_unblocks() {
+    let _lock = DevServerLock::acquire();
+    let _dev_server = DevServer::start().await;
+
+    let app_name = e2e_support::unique_name("function-config-priority-app");
+    let event_name = e2e_support::unique_name("test.function.priority");
+
+    let client = Inngest::new(&app_name).dev(e2e_support::DEV_SERVER_ORIGIN);
+    let step_starts = Arc::new(Mutex::new(Vec::<String>::new()));
+
+    let step_starts_capture = Arc::clone(&step_starts);
+    let func: ServableFn<PrioritizedEventData, Error> = client.create_function(
+        FunctionOpts::new("priority-parent")
+            .name("Priority Parent")
+            .priority(FunctionPriority::new().run("event.data.priority"))
+            .concurrency(FunctionConcurrency::limit(1)),
+        Trigger::event(&event_name),
+        move |input: Input<PrioritizedEventData>, step: StepTool| {
+            let step_starts_capture = Arc::clone(&step_starts_capture);
+
+            async move {
+                let message = input.event.data.message.clone();
+                let step_result: String = step
+                    .run("priority-step", {
+                        let message = message.clone();
+                        move || {
+                            let step_starts_capture = Arc::clone(&step_starts_capture);
+                            let message = message.clone();
+
+                            async move {
+                                step_starts_capture.lock().unwrap().push(message.clone());
+
+                                if message == "blocker" {
+                                    tokio::time::sleep(Duration::from_millis(1500)).await;
+                                }
+
+                                Ok::<_, E2eTestError>(message)
+                            }
+                        }
+                    })
+                    .await?;
+
+                Ok(json!({ "message": step_result }))
+            }
+        },
+    );
+
+    let app = spawn_app(client.clone(), vec![func.into()]).await;
+    app.sync().await;
+
+    client
+        .send_event(&Event::new(
+            &event_name,
+            PrioritizedEventData {
+                message: "blocker".to_string(),
+                priority: 0,
+            },
+        ))
+        .await
+        .expect("blocking priority event should send successfully");
+
+    wait_for_value(&step_starts, Duration::from_secs(10), |starts| {
+        starts.iter().any(|message| message == "blocker")
+    })
+    .await;
+
+    client
+        .send_event(&Event::new(
+            &event_name,
+            PrioritizedEventData {
+                message: "low".to_string(),
+                priority: -10,
+            },
+        ))
+        .await
+        .expect("low priority event should send successfully");
+
+    client
+        .send_event(&Event::new(
+            &event_name,
+            PrioritizedEventData {
+                message: "high".to_string(),
+                priority: 10,
+            },
+        ))
+        .await
+        .expect("high priority event should send successfully");
+
+    let starts = wait_for_value(&step_starts, Duration::from_secs(20), |starts| {
+        starts.len() == 3
+    })
+    .await;
+
+    assert_eq!(
+        starts,
+        vec!["blocker".to_string(), "high".to_string(), "low".to_string()]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn singleton_skip_suppresses_a_second_run_for_the_same_key() {
     let _lock = DevServerLock::acquire();
     let _dev_server = DevServer::start().await;
@@ -506,7 +618,10 @@ async fn singleton_skip_suppresses_a_second_run_for_the_same_key() {
         .await
         .expect("first singleton event should send successfully");
 
-    let started = wait_for_value(&started_runs, Duration::from_secs(5), |runs| !runs.is_empty()).await;
+    let started = wait_for_value(&started_runs, Duration::from_secs(5), |runs| {
+        !runs.is_empty()
+    })
+    .await;
     let first_run_id = started
         .keys()
         .next()
@@ -532,6 +647,108 @@ async fn singleton_skip_suppresses_a_second_run_for_the_same_key() {
     assert_eq!(
         started.values().cloned().collect::<Vec<_>>(),
         vec!["first".to_string()]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn singleton_cancel_replaces_an_in_flight_run_for_the_same_key() {
+    let _lock = DevServerLock::acquire();
+    let _dev_server = DevServer::start().await;
+
+    let app_name = e2e_support::unique_name("function-config-singleton-cancel-app");
+    let event_name = e2e_support::unique_name("test.function.singleton.cancel");
+
+    let client = Inngest::new(&app_name).dev(e2e_support::DEV_SERVER_ORIGIN);
+    let started_runs = Arc::new(Mutex::new(HashMap::<String, String>::new()));
+    let completed_messages = Arc::new(Mutex::new(Vec::<String>::new()));
+
+    let started_runs_capture = Arc::clone(&started_runs);
+    let completed_messages_capture = Arc::clone(&completed_messages);
+    let func: ServableFn<KeyedEventData, Error> = client.create_function(
+        FunctionOpts::new("singleton-cancel-parent")
+            .name("Singleton Cancel Parent")
+            .singleton(FunctionSingleton::new(FunctionSingletonMode::Cancel).key("event.data.key")),
+        Trigger::event(&event_name),
+        move |input: Input<KeyedEventData>, step: StepTool| {
+            let started_runs_capture = Arc::clone(&started_runs_capture);
+            let completed_messages_capture = Arc::clone(&completed_messages_capture);
+
+            async move {
+                started_runs_capture
+                    .lock()
+                    .unwrap()
+                    .insert(input.event.data.message.clone(), input.ctx.run_id.clone());
+
+                if input.event.data.message == "first" {
+                    step.sleep("hold-singleton-cancel", Duration::from_secs(5))?;
+                }
+
+                completed_messages_capture
+                    .lock()
+                    .unwrap()
+                    .push(input.event.data.message.clone());
+
+                Ok(json!({ "message": input.event.data.message }))
+            }
+        },
+    );
+
+    let app = spawn_app(client.clone(), vec![func.into()]).await;
+    app.sync().await;
+
+    client
+        .send_event(&Event::new(
+            &event_name,
+            KeyedEventData {
+                key: "group-1".to_string(),
+                message: "first".to_string(),
+            },
+        ))
+        .await
+        .expect("first singleton cancel event should send successfully");
+
+    let started = wait_for_value(&started_runs, Duration::from_secs(5), |runs| {
+        runs.contains_key("first")
+    })
+    .await;
+    let first_run_id = started
+        .get("first")
+        .cloned()
+        .expect("first singleton cancel run should exist");
+
+    client
+        .send_event(&Event::new(
+            &event_name,
+            KeyedEventData {
+                key: "group-1".to_string(),
+                message: "second".to_string(),
+            },
+        ))
+        .await
+        .expect("second singleton cancel event should send successfully");
+
+    let started = wait_for_value(&started_runs, Duration::from_secs(15), |runs| {
+        runs.contains_key("first") && runs.contains_key("second")
+    })
+    .await;
+    let second_run_id = started
+        .get("second")
+        .cloned()
+        .expect("second singleton cancel run should exist");
+
+    let first_run =
+        wait_for_run_status_matching(&first_run_id, Duration::from_secs(20), |status| {
+            status.to_ascii_lowercase().contains("cancel")
+        })
+        .await;
+    let second_run =
+        wait_for_run_status(&second_run_id, "Completed", Duration::from_secs(20)).await;
+
+    assert!(first_run.status.to_ascii_lowercase().contains("cancel"));
+    assert_eq!(second_run.output, json!({ "message": "second" }));
+    assert_eq!(
+        completed_messages.lock().unwrap().clone(),
+        vec!["second".to_string()]
     );
 }
 
@@ -685,8 +902,10 @@ async fn concurrency_limit_serializes_step_execution_across_runs() {
         .await
         .expect("first concurrency event should send successfully");
 
-    wait_for_value(&step_starts, Duration::from_secs(10), |starts| starts.contains_key("first"))
-        .await;
+    wait_for_value(&step_starts, Duration::from_secs(10), |starts| {
+        starts.contains_key("first")
+    })
+    .await;
 
     client
         .send_event(&Event::new(
@@ -762,8 +981,10 @@ async fn throttle_queues_runs_instead_of_dropping_them() {
         .await
         .expect("first throttled event should send successfully");
 
-    wait_for_value(&run_starts, Duration::from_secs(10), |starts| starts.contains_key("first"))
-        .await;
+    wait_for_value(&run_starts, Duration::from_secs(10), |starts| {
+        starts.contains_key("first")
+    })
+    .await;
 
     client
         .send_event(&Event::new(

--- a/inngest/tests/function_config_e2e.rs
+++ b/inngest/tests/function_config_e2e.rs
@@ -5,8 +5,9 @@ use inngest::{
     client::Inngest,
     event::Event,
     function::{
-        FunctionBatchEvents, FunctionFailureEvent, FunctionOpts, FunctionRateLimit, Input,
-        ServableFn, Trigger,
+        FunctionBatchEvents, FunctionCancel, FunctionConcurrency, FunctionDebounce,
+        FunctionFailureEvent, FunctionOpts, FunctionRateLimit, FunctionSingleton,
+        FunctionSingletonMode, FunctionThrottle, Input, ServableFn, Trigger,
     },
     result::{DevError, Error},
     step_tool::Step as StepTool,
@@ -14,11 +15,13 @@ use inngest::{
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{
+    collections::HashMap,
+    fmt::{Display, Formatter},
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc, Mutex,
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -38,6 +41,106 @@ struct FailureCapture {
 struct BatchCapture {
     messages: Vec<String>,
     primary_message: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct E2eTestError {
+    message: String,
+}
+
+impl Display for E2eTestError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for E2eTestError {}
+
+impl From<E2eTestError> for Error {
+    fn from(err: E2eTestError) -> Self {
+        Error::Dev(DevError::Basic(err.message))
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct KeyedEventData {
+    key: String,
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiEnvelope<T> {
+    data: T,
+}
+
+async fn wait_for_value<T: Clone>(
+    state: &Arc<Mutex<T>>,
+    timeout: Duration,
+    predicate: impl Fn(&T) -> bool,
+) -> T {
+    let deadline = Instant::now() + timeout;
+
+    loop {
+        let value = state.lock().unwrap().clone();
+        if predicate(&value) {
+            return value;
+        }
+
+        assert!(Instant::now() < deadline, "timed out waiting for state predicate");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn fetch_run_record(run_id: &str) -> Option<e2e_support::RunRecord> {
+    let response = reqwest::Client::new()
+        .get(format!("{}/v1/runs/{run_id}", e2e_support::DEV_SERVER_ORIGIN))
+        .send()
+        .await
+        .expect("run lookup should complete");
+
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return None;
+    }
+
+    assert!(
+        response.status().is_success(),
+        "run lookup failed with status {}",
+        response.status()
+    );
+
+    let envelope = response
+        .json::<ApiEnvelope<e2e_support::RunRecord>>()
+        .await
+        .expect("run lookup should decode");
+
+    Some(envelope.data)
+}
+
+async fn wait_for_run_status_matching(
+    run_id: &str,
+    timeout: Duration,
+    predicate: impl Fn(&str) -> bool,
+) -> e2e_support::RunRecord {
+    let deadline = Instant::now() + timeout;
+    let mut last_status = None::<String>;
+
+    loop {
+        if let Some(run) = fetch_run_record(run_id).await {
+            if predicate(&run.status) {
+                return run;
+            }
+
+            last_status = Some(run.status);
+        }
+
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for run {run_id} to reach a matching status; last status was {:?}",
+            last_status
+        );
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -272,4 +375,414 @@ async fn rate_limit_allows_only_one_run_within_the_configured_period() {
         vec!["first".to_string()]
     );
     assert_eq!(run.output, json!({ "message": "first" }));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn debounce_runs_once_with_the_latest_event_payload() {
+    let _lock = DevServerLock::acquire();
+    let _dev_server = DevServer::start().await;
+
+    let app_name = e2e_support::unique_name("function-config-debounce-app");
+    let event_name = e2e_support::unique_name("test.function.debounce");
+
+    let client = Inngest::new(&app_name).dev(e2e_support::DEV_SERVER_ORIGIN);
+    let run_id_state = Arc::new(Mutex::new(None::<String>));
+    let received_messages = Arc::new(Mutex::new(Vec::<String>::new()));
+    let invocation_count = Arc::new(AtomicUsize::new(0));
+
+    let run_id_capture = Arc::clone(&run_id_state);
+    let received_messages_capture = Arc::clone(&received_messages);
+    let invocation_count_capture = Arc::clone(&invocation_count);
+    let func: ServableFn<KeyedEventData, Error> = client.create_function(
+        FunctionOpts::new("debounce-parent")
+            .name("Debounce Parent")
+            .debounce(
+                FunctionDebounce::new(Duration::from_secs(2))
+                    .key("event.data.key")
+                    .timeout(Duration::from_secs(4)),
+            ),
+        Trigger::event(&event_name),
+        move |input: Input<KeyedEventData>, _step: StepTool| {
+            let run_id_capture = Arc::clone(&run_id_capture);
+            let received_messages_capture = Arc::clone(&received_messages_capture);
+            let invocation_count_capture = Arc::clone(&invocation_count_capture);
+
+            async move {
+                invocation_count_capture.fetch_add(1, Ordering::SeqCst);
+                *run_id_capture.lock().unwrap() = Some(input.ctx.run_id.clone());
+                received_messages_capture
+                    .lock()
+                    .unwrap()
+                    .push(input.event.data.message.clone());
+
+                Ok(json!({ "message": input.event.data.message }))
+            }
+        },
+    );
+
+    let app = spawn_app(client.clone(), vec![func.into()]).await;
+    app.sync().await;
+
+    client
+        .send_event(&Event::new(
+            &event_name,
+            KeyedEventData {
+                key: "group-1".to_string(),
+                message: "first".to_string(),
+            },
+        ))
+        .await
+        .expect("first debounced event should send successfully");
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    client
+        .send_event(&Event::new(
+            &event_name,
+            KeyedEventData {
+                key: "group-1".to_string(),
+                message: "second".to_string(),
+            },
+        ))
+        .await
+        .expect("second debounced event should send successfully");
+
+    let run_id = wait_for_state(&run_id_state, Duration::from_secs(10)).await;
+    let run = wait_for_run_status(&run_id, "Completed", Duration::from_secs(15)).await;
+
+    assert_eq!(invocation_count.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        received_messages.lock().unwrap().clone(),
+        vec!["second".to_string()]
+    );
+    assert_eq!(run.output, json!({ "message": "second" }));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn singleton_skip_suppresses_a_second_run_for_the_same_key() {
+    let _lock = DevServerLock::acquire();
+    let _dev_server = DevServer::start().await;
+
+    let app_name = e2e_support::unique_name("function-config-singleton-app");
+    let event_name = e2e_support::unique_name("test.function.singleton");
+
+    let client = Inngest::new(&app_name).dev(e2e_support::DEV_SERVER_ORIGIN);
+    let started_runs = Arc::new(Mutex::new(HashMap::<String, String>::new()));
+
+    let started_runs_capture = Arc::clone(&started_runs);
+    let func: ServableFn<KeyedEventData, Error> = client.create_function(
+        FunctionOpts::new("singleton-parent")
+            .name("Singleton Parent")
+            .singleton(FunctionSingleton::new(FunctionSingletonMode::Skip).key("event.data.key")),
+        Trigger::event(&event_name),
+        move |input: Input<KeyedEventData>, step: StepTool| {
+            let started_runs_capture = Arc::clone(&started_runs_capture);
+
+            async move {
+                started_runs_capture
+                    .lock()
+                    .unwrap()
+                    .entry(input.ctx.run_id.clone())
+                    .or_insert_with(|| input.event.data.message.clone());
+
+                step.sleep("hold-singleton", Duration::from_millis(1500))?;
+
+                Ok(json!({ "message": input.event.data.message }))
+            }
+        },
+    );
+
+    let app = spawn_app(client.clone(), vec![func.into()]).await;
+    app.sync().await;
+
+    client
+        .send_event(&Event::new(
+            &event_name,
+            KeyedEventData {
+                key: "group-1".to_string(),
+                message: "first".to_string(),
+            },
+        ))
+        .await
+        .expect("first singleton event should send successfully");
+
+    let started = wait_for_value(&started_runs, Duration::from_secs(5), |runs| !runs.is_empty()).await;
+    let first_run_id = started
+        .keys()
+        .next()
+        .cloned()
+        .expect("first singleton run should exist");
+
+    client
+        .send_event(&Event::new(
+            &event_name,
+            KeyedEventData {
+                key: "group-1".to_string(),
+                message: "second".to_string(),
+            },
+        ))
+        .await
+        .expect("second singleton event should send successfully");
+
+    wait_for_run_status(&first_run_id, "Completed", Duration::from_secs(15)).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let started = started_runs.lock().unwrap().clone();
+    assert_eq!(started.len(), 1);
+    assert_eq!(
+        started.values().cloned().collect::<Vec<_>>(),
+        vec!["first".to_string()]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancel_stops_an_in_flight_run_when_a_matching_event_arrives() {
+    let _lock = DevServerLock::acquire();
+    let _dev_server = DevServer::start().await;
+
+    let app_name = e2e_support::unique_name("function-config-cancel-app");
+    let start_event_name = e2e_support::unique_name("test.function.cancel.start");
+    let cancel_event_name = e2e_support::unique_name("test.function.cancel.signal");
+
+    let client = Inngest::new(&app_name).dev(e2e_support::DEV_SERVER_ORIGIN);
+    let run_id_state = Arc::new(Mutex::new(None::<String>));
+    let completed_after_sleep = Arc::new(AtomicUsize::new(0));
+
+    let run_id_capture = Arc::clone(&run_id_state);
+    let completed_after_sleep_capture = Arc::clone(&completed_after_sleep);
+    let func: ServableFn<KeyedEventData, Error> = client.create_function(
+        FunctionOpts::new("cancel-parent")
+            .name("Cancel Parent")
+            .cancel(
+                FunctionCancel::new(&cancel_event_name)
+                    .if_exp("event.data.key == async.data.key")
+                    .timeout(Duration::from_secs(5)),
+            ),
+        Trigger::event(&start_event_name),
+        move |input: Input<KeyedEventData>, step: StepTool| {
+            let run_id_capture = Arc::clone(&run_id_capture);
+            let completed_after_sleep_capture = Arc::clone(&completed_after_sleep_capture);
+
+            async move {
+                if run_id_capture.lock().unwrap().is_none() {
+                    *run_id_capture.lock().unwrap() = Some(input.ctx.run_id.clone());
+                }
+
+                step.sleep("hold-cancel", Duration::from_secs(5))?;
+                completed_after_sleep_capture.fetch_add(1, Ordering::SeqCst);
+
+                Ok(json!({ "message": input.event.data.message }))
+            }
+        },
+    );
+
+    let app = spawn_app(client.clone(), vec![func.into()]).await;
+    app.sync().await;
+
+    client
+        .send_event(&Event::new(
+            &start_event_name,
+            KeyedEventData {
+                key: "group-1".to_string(),
+                message: "first".to_string(),
+            },
+        ))
+        .await
+        .expect("start event should send successfully");
+
+    let run_id = wait_for_state(&run_id_state, Duration::from_secs(5)).await;
+    wait_for_run_status(&run_id, "Running", Duration::from_secs(5)).await;
+
+    client
+        .send_event(&Event::new(
+            &cancel_event_name,
+            KeyedEventData {
+                key: "group-1".to_string(),
+                message: "cancel".to_string(),
+            },
+        ))
+        .await
+        .expect("cancel event should send successfully");
+
+    let run = wait_for_run_status_matching(&run_id, Duration::from_secs(15), |status| {
+        let normalized = status.to_ascii_lowercase();
+        normalized.contains("cancel")
+    })
+    .await;
+
+    assert!(run.status.to_ascii_lowercase().contains("cancel"));
+    assert_eq!(completed_after_sleep.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrency_limit_serializes_step_execution_across_runs() {
+    let _lock = DevServerLock::acquire();
+    let _dev_server = DevServer::start().await;
+
+    let app_name = e2e_support::unique_name("function-config-concurrency-app");
+    let event_name = e2e_support::unique_name("test.function.concurrency");
+
+    let client = Inngest::new(&app_name).dev(e2e_support::DEV_SERVER_ORIGIN);
+    let step_starts = Arc::new(Mutex::new(HashMap::<String, Instant>::new()));
+    let step_ends = Arc::new(Mutex::new(HashMap::<String, Instant>::new()));
+
+    let step_starts_capture = Arc::clone(&step_starts);
+    let step_ends_capture = Arc::clone(&step_ends);
+    let func: ServableFn<KeyedEventData, Error> = client.create_function(
+        FunctionOpts::new("concurrency-parent")
+            .name("Concurrency Parent")
+            .concurrency(FunctionConcurrency::limit(1)),
+        Trigger::event(&event_name),
+        move |input: Input<KeyedEventData>, step: StepTool| {
+            let step_starts_capture = Arc::clone(&step_starts_capture);
+            let step_ends_capture = Arc::clone(&step_ends_capture);
+
+            async move {
+                let message = input.event.data.message.clone();
+                let step_result: String = step
+                    .run("blocking-step", {
+                        let message = message.clone();
+                        move || {
+                            let step_starts_capture = Arc::clone(&step_starts_capture);
+                            let step_ends_capture = Arc::clone(&step_ends_capture);
+                            let message = message.clone();
+
+                            async move {
+                                step_starts_capture
+                                    .lock()
+                                    .unwrap()
+                                    .entry(message.clone())
+                                    .or_insert_with(Instant::now);
+                                tokio::time::sleep(Duration::from_millis(1500)).await;
+                                step_ends_capture
+                                    .lock()
+                                    .unwrap()
+                                    .entry(message.clone())
+                                    .or_insert_with(Instant::now);
+
+                                Ok::<_, E2eTestError>(message.clone())
+                            }
+                        }
+                    })
+                    .await?;
+
+                Ok(json!({ "message": step_result }))
+            }
+        },
+    );
+
+    let app = spawn_app(client.clone(), vec![func.into()]).await;
+    app.sync().await;
+
+    client
+        .send_event(&Event::new(
+            &event_name,
+            KeyedEventData {
+                key: "first".to_string(),
+                message: "first".to_string(),
+            },
+        ))
+        .await
+        .expect("first concurrency event should send successfully");
+
+    wait_for_value(&step_starts, Duration::from_secs(10), |starts| starts.contains_key("first"))
+        .await;
+
+    client
+        .send_event(&Event::new(
+            &event_name,
+            KeyedEventData {
+                key: "second".to_string(),
+                message: "second".to_string(),
+            },
+        ))
+        .await
+        .expect("second concurrency event should send successfully");
+
+    let starts = wait_for_value(&step_starts, Duration::from_secs(20), |starts| {
+        starts.contains_key("first") && starts.contains_key("second")
+    })
+    .await;
+    let ends = wait_for_value(&step_ends, Duration::from_secs(20), |ends| {
+        ends.contains_key("first") && ends.contains_key("second")
+    })
+    .await;
+
+    let first_end = ends["first"];
+    let second_start = starts["second"];
+    assert!(
+        second_start >= first_end,
+        "second step started before the first step finished"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn throttle_queues_runs_instead_of_dropping_them() {
+    let _lock = DevServerLock::acquire();
+    let _dev_server = DevServer::start().await;
+
+    let app_name = e2e_support::unique_name("function-config-throttle-app");
+    let event_name = e2e_support::unique_name("test.function.throttle");
+
+    let client = Inngest::new(&app_name).dev(e2e_support::DEV_SERVER_ORIGIN);
+    let run_starts = Arc::new(Mutex::new(HashMap::<String, Instant>::new()));
+
+    let run_starts_capture = Arc::clone(&run_starts);
+    let func: ServableFn<KeyedEventData, Error> = client.create_function(
+        FunctionOpts::new("throttle-parent")
+            .name("Throttle Parent")
+            .throttle(FunctionThrottle::new(1, Duration::from_secs(2))),
+        Trigger::event(&event_name),
+        move |input: Input<KeyedEventData>, _step: StepTool| {
+            let run_starts_capture = Arc::clone(&run_starts_capture);
+
+            async move {
+                run_starts_capture
+                    .lock()
+                    .unwrap()
+                    .entry(input.event.data.message.clone())
+                    .or_insert_with(Instant::now);
+
+                Ok(json!({ "message": input.event.data.message }))
+            }
+        },
+    );
+
+    let app = spawn_app(client.clone(), vec![func.into()]).await;
+    app.sync().await;
+
+    client
+        .send_event(&Event::new(
+            &event_name,
+            KeyedEventData {
+                key: "first".to_string(),
+                message: "first".to_string(),
+            },
+        ))
+        .await
+        .expect("first throttled event should send successfully");
+
+    wait_for_value(&run_starts, Duration::from_secs(10), |starts| starts.contains_key("first"))
+        .await;
+
+    client
+        .send_event(&Event::new(
+            &event_name,
+            KeyedEventData {
+                key: "second".to_string(),
+                message: "second".to_string(),
+            },
+        ))
+        .await
+        .expect("second throttled event should send successfully");
+
+    let starts = wait_for_value(&run_starts, Duration::from_secs(20), |starts| {
+        starts.contains_key("first") && starts.contains_key("second")
+    })
+    .await;
+
+    assert!(
+        starts["second"].duration_since(starts["first"]) >= Duration::from_secs(1),
+        "throttled second run started too quickly"
+    );
 }

--- a/inngest/tests/function_config_e2e.rs
+++ b/inngest/tests/function_config_e2e.rs
@@ -1,0 +1,105 @@
+mod e2e_support;
+
+use e2e_support::{spawn_app, wait_for_run_status, wait_for_state, DevServer, DevServerLock};
+use inngest::{
+    client::Inngest,
+    event::Event,
+    function::{FunctionFailureEvent, FunctionOpts, Input, ServableFn, Trigger},
+    result::{DevError, Error},
+    step_tool::Step as StepTool,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct FailureEventData {
+    message: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct FailureCapture {
+    function_id: String,
+    original_message: String,
+    run_id: String,
+    error_message: String,
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn on_failure_runs_after_a_function_exhausts_retries() {
+    let _lock = DevServerLock::acquire();
+    let _dev_server = DevServer::start().await;
+
+    let app_name = e2e_support::unique_name("function-config-e2e-app");
+    let event_name = e2e_support::unique_name("test.function.failure");
+
+    let client = Inngest::new(&app_name).dev(e2e_support::DEV_SERVER_ORIGIN);
+    let failed_run_id = Arc::new(Mutex::new(None::<String>));
+    let failure_capture = Arc::new(Mutex::new(None::<FailureCapture>));
+
+    let failed_run_capture = Arc::clone(&failed_run_id);
+    let failure_capture_state = Arc::clone(&failure_capture);
+    let func: ServableFn<FailureEventData, Error> = client
+        .create_function(
+            FunctionOpts::new("failure-parent")
+                .name("Failure Parent")
+                .retries(0),
+            Trigger::event(&event_name),
+            move |input: Input<FailureEventData>, _step: StepTool| {
+                let failed_run_capture = Arc::clone(&failed_run_capture);
+
+                async move {
+                    *failed_run_capture.lock().unwrap() = Some(input.ctx.run_id.clone());
+                    Err(Error::Dev(DevError::Basic("boom".to_string())))
+                }
+            },
+        )
+        .on_failure(
+            move |input: Input<FunctionFailureEvent<FailureEventData>>, _step: StepTool| {
+                let failure_capture_state = Arc::clone(&failure_capture_state);
+
+                async move {
+                    *failure_capture_state.lock().unwrap() = Some(FailureCapture {
+                        function_id: input.event.data.function_id.clone(),
+                        original_message: input.event.data.event.data.message.clone(),
+                        run_id: input.event.data.run_id.clone(),
+                        error_message: input.event.data.error.message.clone(),
+                    });
+
+                    Ok(json!({ "handled": true }))
+                }
+            },
+        );
+
+    let parent_fn_id = func.slug();
+    let app = spawn_app(client.clone(), vec![func.into()]).await;
+    app.sync().await;
+
+    client
+        .send_event(&Event::new(
+            &event_name,
+            FailureEventData {
+                message: "hello".to_string(),
+            },
+        ))
+        .await
+        .expect("failure event should send successfully");
+
+    let run_id = wait_for_state(&failed_run_id, Duration::from_secs(5)).await;
+    let run = wait_for_run_status(&run_id, "Failed", Duration::from_secs(20)).await;
+    let capture = wait_for_state(&failure_capture, Duration::from_secs(20)).await;
+
+    assert_eq!(run.status, "Failed");
+    assert_eq!(
+        capture,
+        FailureCapture {
+            function_id: parent_fn_id,
+            original_message: "hello".to_string(),
+            run_id,
+            error_message: "boom".to_string(),
+        }
+    );
+}

--- a/inngest/tests/function_config_e2e.rs
+++ b/inngest/tests/function_config_e2e.rs
@@ -4,14 +4,20 @@ use e2e_support::{spawn_app, wait_for_run_status, wait_for_state, DevServer, Dev
 use inngest::{
     client::Inngest,
     event::Event,
-    function::{FunctionFailureEvent, FunctionOpts, Input, ServableFn, Trigger},
+    function::{
+        FunctionBatchEvents, FunctionFailureEvent, FunctionOpts, FunctionRateLimit, Input,
+        ServableFn, Trigger,
+    },
     result::{DevError, Error},
     step_tool::Step as StepTool,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{
-    sync::{Arc, Mutex},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
     time::Duration,
 };
 
@@ -26,6 +32,12 @@ struct FailureCapture {
     original_message: String,
     run_id: String,
     error_message: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct BatchCapture {
+    messages: Vec<String>,
+    primary_message: String,
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -102,4 +114,162 @@ async fn on_failure_runs_after_a_function_exhausts_retries() {
             error_message: "boom".to_string(),
         }
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn batch_events_delivers_multiple_events_to_one_function_run() {
+    let _lock = DevServerLock::acquire();
+    let _dev_server = DevServer::start().await;
+
+    let app_name = e2e_support::unique_name("function-config-batch-app");
+    let event_name = e2e_support::unique_name("test.function.batch");
+
+    let client = Inngest::new(&app_name).dev(e2e_support::DEV_SERVER_ORIGIN);
+    let batch_run_id = Arc::new(Mutex::new(None::<String>));
+    let batch_capture = Arc::new(Mutex::new(None::<BatchCapture>));
+
+    let batch_run_state = Arc::clone(&batch_run_id);
+    let batch_capture_state = Arc::clone(&batch_capture);
+    let func: ServableFn<FailureEventData, Error> = client.create_function(
+        FunctionOpts::new("batch-parent")
+            .name("Batch Parent")
+            .batch_events(FunctionBatchEvents::new(2, Duration::from_secs(2))),
+        Trigger::event(&event_name),
+        move |input: Input<FailureEventData>, _step: StepTool| {
+            let batch_run_state = Arc::clone(&batch_run_state);
+            let batch_capture_state = Arc::clone(&batch_capture_state);
+
+            async move {
+                *batch_run_state.lock().unwrap() = Some(input.ctx.run_id.clone());
+
+                let messages = input
+                    .events
+                    .iter()
+                    .map(|event| event.data.message.clone())
+                    .collect::<Vec<_>>();
+                *batch_capture_state.lock().unwrap() = Some(BatchCapture {
+                    primary_message: input.event.data.message.clone(),
+                    messages: messages.clone(),
+                });
+
+                Ok(json!({
+                    "primary": input.event.data.message,
+                    "messages": messages,
+                }))
+            }
+        },
+    );
+
+    let app = spawn_app(client.clone(), vec![func.into()]).await;
+    app.sync().await;
+
+    let first = Event::new(
+        &event_name,
+        FailureEventData {
+            message: "first".to_string(),
+        },
+    );
+    let second = Event::new(
+        &event_name,
+        FailureEventData {
+            message: "second".to_string(),
+        },
+    );
+
+    client
+        .send_events(&[&first, &second])
+        .await
+        .expect("batched events should send successfully");
+
+    let run_id = wait_for_state(&batch_run_id, Duration::from_secs(5)).await;
+    let run = wait_for_run_status(&run_id, "Completed", Duration::from_secs(15)).await;
+    let capture = wait_for_state(&batch_capture, Duration::from_secs(5)).await;
+
+    assert_eq!(capture.messages.len(), 2);
+    assert!(capture.messages.contains(&"first".to_string()));
+    assert!(capture.messages.contains(&"second".to_string()));
+    assert!(capture.messages.contains(&capture.primary_message));
+    assert_eq!(
+        run.output,
+        json!({
+            "primary": capture.primary_message,
+            "messages": capture.messages,
+        })
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rate_limit_allows_only_one_run_within_the_configured_period() {
+    let _lock = DevServerLock::acquire();
+    let _dev_server = DevServer::start().await;
+
+    let app_name = e2e_support::unique_name("function-config-rate-limit-app");
+    let event_name = e2e_support::unique_name("test.function.rate-limit");
+
+    let client = Inngest::new(&app_name).dev(e2e_support::DEV_SERVER_ORIGIN);
+    let rate_limited_run_id = Arc::new(Mutex::new(None::<String>));
+    let received_messages = Arc::new(Mutex::new(Vec::<String>::new()));
+    let invocation_count = Arc::new(AtomicUsize::new(0));
+
+    let rate_limited_run_state = Arc::clone(&rate_limited_run_id);
+    let received_messages_state = Arc::clone(&received_messages);
+    let invocation_count_state = Arc::clone(&invocation_count);
+    let func: ServableFn<FailureEventData, Error> = client.create_function(
+        FunctionOpts::new("rate-limit-parent")
+            .name("Rate Limit Parent")
+            .rate_limit(FunctionRateLimit::new(1, Duration::from_secs(30))),
+        Trigger::event(&event_name),
+        move |input: Input<FailureEventData>, _step: StepTool| {
+            let rate_limited_run_state = Arc::clone(&rate_limited_run_state);
+            let received_messages_state = Arc::clone(&received_messages_state);
+            let invocation_count_state = Arc::clone(&invocation_count_state);
+
+            async move {
+                invocation_count_state.fetch_add(1, Ordering::SeqCst);
+                *rate_limited_run_state.lock().unwrap() = Some(input.ctx.run_id.clone());
+                received_messages_state
+                    .lock()
+                    .unwrap()
+                    .push(input.event.data.message.clone());
+
+                Ok(json!({ "message": input.event.data.message }))
+            }
+        },
+    );
+
+    let app = spawn_app(client.clone(), vec![func.into()]).await;
+    app.sync().await;
+
+    client
+        .send_event(&Event::new(
+            &event_name,
+            FailureEventData {
+                message: "first".to_string(),
+            },
+        ))
+        .await
+        .expect("first rate-limited event should send successfully");
+
+    let run_id = wait_for_state(&rate_limited_run_id, Duration::from_secs(5)).await;
+
+    client
+        .send_event(&Event::new(
+            &event_name,
+            FailureEventData {
+                message: "second".to_string(),
+            },
+        ))
+        .await
+        .expect("second rate-limited event should send successfully");
+
+    let run = wait_for_run_status(&run_id, "Completed", Duration::from_secs(15)).await;
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    assert_eq!(invocation_count.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        received_messages.lock().unwrap().clone(),
+        vec!["first".to_string()]
+    );
+    assert_eq!(run.output, json!({ "message": "first" }));
 }

--- a/inngest/tests/function_config_e2e.rs
+++ b/inngest/tests/function_config_e2e.rs
@@ -537,27 +537,32 @@ async fn priority_prefers_higher_priority_runs_once_concurrency_unblocks() {
     })
     .await;
 
-    client
-        .send_event(&Event::new(
-            &event_name,
-            PrioritizedEventData {
-                message: "low".to_string(),
-                priority: -10,
-            },
-        ))
-        .await
-        .expect("low priority event should send successfully");
+    let future_ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock should be after unix epoch")
+        .as_millis() as i64
+        + 3_000;
+    let low = Event::new(
+        &event_name,
+        PrioritizedEventData {
+            message: "low".to_string(),
+            priority: -10,
+        },
+    )
+    .timestamp(future_ts);
+    let high = Event::new(
+        &event_name,
+        PrioritizedEventData {
+            message: "high".to_string(),
+            priority: 10,
+        },
+    )
+    .timestamp(future_ts);
 
     client
-        .send_event(&Event::new(
-            &event_name,
-            PrioritizedEventData {
-                message: "high".to_string(),
-                priority: 10,
-            },
-        ))
+        .send_events(&[&low, &high])
         .await
-        .expect("high priority event should send successfully");
+        .expect("priority events should send successfully");
 
     let starts = wait_for_value(&step_starts, Duration::from_secs(20), |starts| {
         starts.len() == 3


### PR DESCRIPTION
## Summary
This PR implements the Rust SDK function config surface.

It adds the public function-definition metadata needed for sync payload parity, validates supported config shapes during sync payload construction, and introduces a Rust-style `on_failure(...)` API backed by an internal `inngest/function.failed` handler function.

## What changed
- add public function config types and builder methods for `cancel`, `idempotency`, `batch_events`, `rate_limit`, `debounce`, `priority`, `concurrency`, `throttle`, `singleton`, and `timeouts`
- serialize the new function config surface into sync payloads
- omit `rateLimit` from the synced payload when `idempotency` is set
- validate supported config shapes during sync payload construction
- add a Rust-style `ServableFn::on_failure(...)` API
- register `on_failure` handlers as internal `inngest/function.failed` functions with separate retries and without inheriting concurrency or singleton settings
- update README support notes and mark plan 004 complete

## Validation behavior
Invalid config shapes are rejected when the sync payload is built.

Current explicit validation covers:
- `batchEvents.maxSize` must be between `1` and `100`
- duration-based `batchEvents.timeout` must be between `1s` and `60s`
- keyed `concurrency` supports at most two entries
- empty string time values are rejected

## Testing
- `make lint`
- `cargo test -p inngest sync_payload_ -- --nocapture`
- `cargo test -p inngest internal_failure -- --nocapture`

## Notes
The branch also contains the earlier `AGENTS.md` tweak and plan-refinement commit that preceded the implementation work.